### PR TITLE
Add SDK support an HTTPOnly cookie service

### DIFF
--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -4,6 +4,7 @@ import { getCDN, setGlobalCDNUrl } from '../lib/parse-cdn'
 import { fetch } from '../lib/fetch'
 import { Analytics, AnalyticsSettings, InitOptions } from '../core/analytics'
 import { Context } from '../core/context'
+import { HTTPCookieService } from '../core/http-cookies'
 import { Plan } from '../core/events'
 import { Plugin } from '../core/plugin'
 import { MetricsOptions } from '../core/stats/remote-metrics'
@@ -358,6 +359,12 @@ async function loadAnalytics(
 
   const retryQueue: boolean =
     legacySettings.integrations['Hightouch.io']?.retryQueue ?? true
+
+  if (!options.disableClientPersistence && options.httpCookieServiceOptions) {
+    options.httpCookieService = await HTTPCookieService.load(
+      options.httpCookieServiceOptions
+    )
+  }
 
   const opts: InitOptions = { retryQueue, ...options }
   const analytics = new Analytics(settings, opts)

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -138,7 +138,7 @@ export interface InitOptions {
    */
   httpCookieServiceOptions?: HTTPCookieServiceOptions
   /**
-   * When not setting httpCookieServiceOptions, you may pass your own instance
+   * When not setting httpCookieServiceOptions, you may pass your own instance of HTTPCookieService
    */
   httpCookieService?: HTTPCookieService
 

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -55,6 +55,10 @@ import {
 import { PluginFactory } from '../../plugins/remote-loader'
 import { setGlobalAnalytics } from '../../lib/global-analytics-helper'
 import { popPageContext } from '../buffer'
+import type {
+  HTTPCookieService,
+  HTTPCookieServiceOptions,
+} from '../http-cookies'
 
 const deprecationWarning =
   'This is being deprecated and will be not be available in future releases of Analytics JS'
@@ -130,6 +134,15 @@ export interface InitOptions {
   globalAnalyticsKey?: string
 
   /**
+   * When setting httpCookieServiceOptions, an HTTPCookieService is automatically created
+   */
+  httpCookieServiceOptions?: HTTPCookieServiceOptions
+  /**
+   * When not setting httpCookieServiceOptions, you may pass your own instance
+   */
+  httpCookieService?: HTTPCookieService
+
+  /**
    * Shortcuts for overriding the default Hightouch.io integration settings
    */
   apiHost?: string // Defaults to us-east-1.hightouch-events.com
@@ -191,6 +204,7 @@ export class Analytics
         {
           persist: !disablePersistance,
           storage: options?.storage,
+          httpCookieService: options?.httpCookieService,
           // Any User specific options override everything else
           ...options?.user,
         },

--- a/packages/browser/src/core/http-cookies/README.md
+++ b/packages/browser/src/core/http-cookies/README.md
@@ -31,7 +31,7 @@ A user visiting a website on both 01/01/2023 and 01/14/2023 can still look like 
 1. If `$server` is on a subdomain of the website, its IP address must match the IP address that served the main HTML document.
 
 Routing a subdomain via DNS will not suffice. You'll need **one of** the following:
-- A **webserver** that serves  both your HTML document and a programamtic API (e.g. something like Django, Rails, Spring, etc)
+- A **webserver** that serves  both your HTML document and an API (e.g. something like Django, Rails, Spring, etc)
 - A **reverse proxy** that can forward requests for your HTML document to one place, your API requests to another, and make it look like it's all on one server (e.g. NGINX, Caddy, etc)
 - A **CDN** that can run programmatic logic when matching certain requests (e.g. Lambda@Edge, Clouflare Workers, etc)
 

--- a/packages/browser/src/core/http-cookies/README.md
+++ b/packages/browser/src/core/http-cookies/README.md
@@ -31,21 +31,164 @@ A user visiting a website on both 01/01/2023 and 01/14/2023 can still look like 
 1. If `$server` is on a subdomain of the website, its IP address must match the IP address that served the main HTML document.
 
 Routing a subdomain via DNS will not suffice. You'll need **one of** the following:
-- A **webserver** that serves  both your HTML document and a programamtic API (e.g. something like Django, Rails, Springboot, etc)
+- A **webserver** that serves  both your HTML document and a programamtic API (e.g. something like Django, Rails, Spring, etc)
 - A **reverse proxy** that can forward requests for your HTML document to one place, your API requests to another, and make it look like it's all on one server (e.g. NGINX, Caddy, etc)
 - A **CDN** that can run programmatic logic when matching certain requests (e.g. Lambda@Edge, Clouflare Workers, etc)
 
-## `$Server` Definition
+## Client SDK Setup
 
-The Events SDK expects to interact with a `$server` that implements the following API:
+```javascript
+import { HtEventsBrowser } from '@ht-sdks/events-sdk-js-browser'
 
-1. A route for **renewing**/**creating** cookies
-_ TODO FINISH THIS
-2. A route for **clearing** cookies
+const htevents = HtEventsBrowser.load(
+  { writeKey: '<YOUR_WRITE_KEY>'},
+  { 
+    apiHost: "us-east-1.hightouch-events.com", // HtEvents API remains the same
+    httpCookieServiceOptions: {
+      clearUrl: 'ht/clear', // route hosted on *your* domain and infra
+      renewUrl: 'ht/renew', // route hosted on *your* domain and infra
+    }
+  },
+)
 
-You can name the endpoints whatever you want. You pass this information to the Events SDK during configuration.
+htevents.identify('hello world')
 
+document.body?.addEventListener('click', () => {
+  htevents.track('document body clicked!')
+})
+```
 
+## Server Setup
 
+The Events SDK expects to interact with a customer's `$server` that implements a specific spec for two routes. You can name the endpoints whatever you want.
 
+### An API for **creating** server and browser cookies
+
+This route should look for the following **browser** cookies (from Events SDK):
+* `request.headers.get('Cookie')["htjs_anonymous_id"]`
+* `request.headers.get('Cookie')["htjs_user_id"]`
+
+This route should return these values as **server** cookies:
+* `response.cookie("htjs_anonymous_id_srvr", anonVal, {httpOnly:true, ...})`
+* `response.cookie("htjs_user_id_srvr", userIdVal, {httpOnly:true, ...})`
+
+If there are no browser cookies found, return any server cookies as browser cookies:
+* `response.cookie("htjs_anonymous_id", anonVal, ...)`
+* `response.cookie("htjs_user_id", userIdVal, ...)`
+
+### An API for **clearing** server cookies
+
+This route should look for **server** cookies and clean them:
+* `res.cookie("htjs_anonymous_id_srvr", "", {maxAge: 0, httpOnly:true});`
+* `res.cookie("htjs_user_id_srvr", "", {maxAge: 0, httpOnly:true});`
+
+### API Spec
+The spec of the actual `request` and `response` payloads are kept intentionally vague. The spec should fit a variety of server environments.
+
+The Events SDK only requires that the server: A) handles cookies and B) returns a `200` statuscode.
+
+## Server Example
+
+A simplified Node.js/Express server:
+
+```Javascript
+const express = require("express");
+const cookieParser = require('cookie-parser');
+const cors = require('cors');
+
+const USER_COOKIE = "htjs_user_id";
+const ANON_COOKIE = "htjs_anonymous_id";
+
+function getDomain(req) {
+  let domain = process.env.DOMAIN || req.headers["x-forwarded-for"] || req.get("host");
+  if (domain.startsWith("localhost")) return "localhost";
+  return domain;
+}
+
+function renewCookies(req, res, browserName, serverName) {
+  const cookie = req.cookies[browserName] || req.cookies[serverName];
+  if (!cookie) return "";
+  const cookieParams = {maxAge:31536000*1000, domain: getDomain(req), sameSite: "lax"};
+  res.cookie(browserName, cookie, {...cookieParams});
+  res.cookie(serverName, cookie, {...cookieParams, httpOnly:true});
+  return cookie;
+}
+
+function clearServerCookie(req, res, serverName) {
+  const cookie = "";
+  const cookieParams = {maxAge:0, domain: getDomain(req), sameSite: "lax"};
+  res.cookie(serverName, "", {...cookieParams, httpOnly:true});
+  return cookie;
+}
+
+const app = express();
+app.use(cookieParser());
+app.use(cors())
+
+app.post("/ht/renew", (req, res) => {
+  // recreate a browser cookie from an existing server cookie, OR
+  // create a new server cookie that can later be used to recreate from.
+  return res.json({
+    userId: renewCookies(req, res, USER_COOKIE, `${USER_COOKIE}_srvr`),
+    anonymousId: renewCookies(req, res, ANON_COOKIE, `${ANON_COOKIE}_srvr`),
+  })
+});
+
+app.post("/ht/clear", (req, res) => {
+  // clear server cookies, e.g. if the user asks to clear all cookies.
+  return res.json({
+    userId: clearServerCookie(req, res, `${USER_COOKIE}_srvr`),
+    anonymousId: clearServerCookie(req, res, `${ANON_COOKIE}_srvr`),
+  })
+});
+
+app.listen(3000, () => {
+  console.log("Listening on port 3000...");
+});
+```
+
+A **very** simplified NGINX reverse proxy serving your document and API from the same domain:
+```
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        location / {
+            root   /Users/name/src/website/html;
+            index  index.html index.htm;
+        }
+
+        location /cdn {
+            #autoindex on;
+            alias  /Users/name/src/website/cdn;
+            try_files $uri /index.html =404;
+        }
+
+        location /ht {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_pass http://127.0.0.1:3000;
+        }
+
+    }
+
+    include servers/*;
+}
+```
+
+**These server examples should not be used as is.** They should be adapted to your setup and "productionized". The general concepts remain the same though.
+
+## More information
+- Safari: https://webkit.org/blog/9521/intelligent-tracking-prevention-2-3/
 

--- a/packages/browser/src/core/http-cookies/README.md
+++ b/packages/browser/src/core/http-cookies/README.md
@@ -1,0 +1,51 @@
+# HTTPOnly Cookies
+
+## "Browser Cookies" vs "Server Cookies"
+
+**Cookies are serialized sets of key-value pairs that the browser can send to the server when making an HTTP request (e.g. on the `Cookie` header)**. Traditionally, the browser does this to identify itself when calling the server. For example, it might receive a cookie when calling a `/login` route, and then continue to send this cookie on subsequent requests, proving that the user is still logged-in. Alternatively, browsers can use cookies just for storing local data, like localStorage.
+
+Normally, **both** the client and the server can CRUD cookies.
+
+However, as a security measure, browsers restrict Javascript access to cookies containing the `HTTPOnly` property. These cookies are **only** intended to be created and read by the server.
+
+## "Browser Cookies" for event attribution
+
+Certain browsers (e.g. Safari) limit "Browser Cookies" to a 7 day expiry.
+
+A user visiting a website on both 01/01/2023 and 01/14/2023 will look like two different users. The browser will delete the user's "anonymousId cookie" before the user begins their second session on 01/14/2023.
+
+## "Server Cookies" for event attribution
+
+These expiry limits don't have to apply to "Server Cookies".
+
+A user visiting a website on both 01/01/2023 and 01/14/2023 can still look like the same user, provided that there is a way to "regenerate" the user's same "anonymousId cookie" from the earlier session. To do this, the following must happen:
+1. User begins their session on 01/01/2023
+1. Events SDK creates an anonymousId "browser cookie"
+1. Events SDK sends "browser cookie" to `$server` and receives back an HTTPOnly cookie with the same anonymousId
+1. HTTPOnly cookie remains on the user's device
+1. User begins their second session on 01/14/2023
+1. Events SDK sends the HTTPOnly cookie to `$server` and receives back a "browser cookie" with the same anonymousId as the first session
+
+**The `$server` must be the same server that serves your website.** Certain browsers (e.g. Safari) will still enforce a 7 day expiry--even for "server cookies"--unless the following criteria are met:
+1. The `$server` providing the HTTPOnly cookie must be on the same domain as the website.
+1. If `$server` is on a subdomain of the website, its IP address must match the IP address that served the main HTML document.
+
+Routing a subdomain via DNS will not suffice. You'll need **one of** the following:
+- A **webserver** that serves  both your HTML document and a programamtic API (e.g. something like Django, Rails, Springboot, etc)
+- A **reverse proxy** that can forward requests for your HTML document to one place, your API requests to another, and make it look like it's all on one server (e.g. NGINX, Caddy, etc)
+- A **CDN** that can run programmatic logic when matching certain requests (e.g. Lambda@Edge, Clouflare Workers, etc)
+
+## `$Server` Definition
+
+The Events SDK expects to interact with a `$server` that implements the following API:
+
+1. A route for **renewing**/**creating** cookies
+_ TODO FINISH THIS
+2. A route for **clearing** cookies
+
+You can name the endpoints whatever you want. You pass this information to the Events SDK during configuration.
+
+
+
+
+

--- a/packages/browser/src/core/http-cookies/__tests__/index.test.ts
+++ b/packages/browser/src/core/http-cookies/__tests__/index.test.ts
@@ -1,0 +1,443 @@
+import { Analytics } from '../../analytics'
+import { HTTPCookieService } from '..'
+import * as fetchLib from '../../../lib/fetch'
+
+async function sleep(delayMS: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMS))
+}
+
+describe('HTTPCookieService', () => {
+  it('renews cookie on load', async () => {
+    const spy = jest.spyOn(fetchLib, 'fetch')
+    spy.mockImplementation(
+      jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
+    )
+
+    await HTTPCookieService.load({
+      renewUrl: 'ht/renewtest',
+      clearUrl: 'ht/cleartest',
+    })
+
+    expect(spy).toHaveBeenCalledWith('ht/renewtest', {
+      body: expect.anything(),
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      method: 'post',
+    })
+    spy.mockRestore()
+  })
+
+  it('renews cookie on load, with retries', async () => {
+    const spy = jest.spyOn(fetchLib, 'fetch')
+    spy.mockImplementation(
+      jest.fn(() =>
+        Promise.resolve({ status: 500, statusText: 'text', ok: false })
+      ) as jest.Mock
+    )
+
+    await HTTPCookieService.load({
+      renewUrl: 'ht/renewtest',
+      clearUrl: 'ht/cleartest',
+    })
+
+    expect(spy).toHaveBeenCalledTimes(3)
+    expect(spy.mock.calls[0]).toEqual(['ht/renewtest', expect.anything()])
+    expect(spy.mock.calls[1]).toEqual(['ht/renewtest', expect.anything()])
+    expect(spy.mock.calls[2]).toEqual(['ht/renewtest', expect.anything()])
+    spy.mockRestore()
+  })
+
+  it('renews cookie on load, with retries set to 0', async () => {
+    const spy = jest.spyOn(fetchLib, 'fetch')
+    spy.mockImplementation(
+      jest.fn(() =>
+        Promise.resolve({ status: 500, statusText: 'text', ok: false })
+      ) as jest.Mock
+    )
+
+    await HTTPCookieService.load({
+      renewUrl: 'ht/renewtest',
+      clearUrl: 'ht/cleartest',
+      retries: 0,
+    })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]).toEqual(['ht/renewtest', expect.anything()])
+    spy.mockRestore()
+  })
+
+  it('dispatches further cookie requests', async () => {
+    const spy = jest.spyOn(fetchLib, 'fetch')
+    spy.mockImplementation(
+      jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
+    )
+
+    const cookieService = await HTTPCookieService.load({
+      renewUrl: 'ht/renewtest',
+      clearUrl: 'ht/cleartest',
+      flushInterval: 10,
+    })
+
+    cookieService.dispatchCreate()
+
+    await sleep(20).then(async () => {
+      await expect(spy).toHaveBeenCalledTimes(2)
+      // this one is from HTTPCookieService.load(...)
+      expect(spy.mock.calls[0]).toEqual(['ht/renewtest', expect.anything()])
+      // this one is from the dispatch
+      expect(spy.mock.calls[1]).toEqual(['ht/renewtest', expect.anything()])
+      spy.mockRestore()
+    })
+  })
+
+  it('dispatches further cookie requests, in the order received', async () => {
+    const spy = jest.spyOn(fetchLib, 'fetch')
+    spy.mockImplementation(
+      jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
+    )
+
+    const cookieService = await HTTPCookieService.load({
+      renewUrl: 'ht/renewtest',
+      clearUrl: 'ht/cleartest',
+      flushInterval: 10,
+    })
+
+    cookieService.dispatchCreate()
+    cookieService.dispatchClear()
+    cookieService.dispatchClear()
+    cookieService.dispatchCreate()
+    cookieService.dispatchCreate()
+    cookieService.dispatchClear()
+    cookieService.dispatchCreate()
+    cookieService.dispatchCreate()
+
+    await sleep(20).then(async () => {
+      await expect(spy).toHaveBeenCalledTimes(9)
+      // this one is from HTTPCookieService.load(...)
+      expect(spy.mock.calls[0]).toEqual(['ht/renewtest', expect.anything()])
+      // these are from the dispatch
+      expect(spy.mock.calls[1]).toEqual(['ht/renewtest', expect.anything()])
+      expect(spy.mock.calls[2]).toEqual(['ht/cleartest', expect.anything()])
+      expect(spy.mock.calls[3]).toEqual(['ht/cleartest', expect.anything()])
+      expect(spy.mock.calls[4]).toEqual(['ht/renewtest', expect.anything()])
+      expect(spy.mock.calls[5]).toEqual(['ht/renewtest', expect.anything()])
+      expect(spy.mock.calls[6]).toEqual(['ht/cleartest', expect.anything()])
+      expect(spy.mock.calls[7]).toEqual(['ht/renewtest', expect.anything()])
+      expect(spy.mock.calls[8]).toEqual(['ht/renewtest', expect.anything()])
+      spy.mockRestore()
+    })
+  })
+
+  it('dispatches to a queue that can be stopped and started', async () => {
+    const spy = jest.spyOn(fetchLib, 'fetch')
+    spy.mockImplementation(
+      jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
+    )
+
+    const cookieService = await HTTPCookieService.load({
+      renewUrl: 'ht/renewtest',
+      clearUrl: 'ht/cleartest',
+      flushInterval: 10,
+      retries: 0,
+      backoff: 0,
+    })
+
+    cookieService.stopQueueConsumer()
+
+    cookieService.dispatchClear()
+
+    await sleep(20).then(async () => {
+      // call from HTTPCookieService.load(...)
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0]).toEqual(['ht/renewtest', expect.anything()])
+    })
+
+    cookieService.startQueueConsumer()
+
+    await sleep(20).then(async () => {
+      // call from the queueConsumer
+      expect(spy).toHaveBeenCalledTimes(2)
+      expect(spy.mock.calls[1]).toEqual(['ht/cleartest', expect.anything()])
+      spy.mockRestore()
+    })
+  })
+})
+
+let analytics: Analytics
+let cookieService: HTTPCookieService
+let fetchSpy: jest.SpyInstance
+
+describe('Analytics - HTTPCookieService - Integration', () => {
+  beforeEach(async () => {
+    fetchSpy = jest.spyOn(fetchLib, 'fetch')
+    fetchSpy.mockImplementation(
+      jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
+    )
+    cookieService = await HTTPCookieService.load({
+      renewUrl: 'ht/renewtest',
+      clearUrl: 'ht/cleartest',
+      flushInterval: 10,
+      retries: 0,
+      backoff: 0,
+    })
+
+    analytics = new Analytics(
+      {
+        writeKey: 'abc',
+      },
+      { httpCookieService: cookieService }
+    )
+    analytics.storage.clear('htjs_anonymous_id')
+    analytics.storage.clear('htjs_user_id')
+  })
+
+  it('calls dispatchCreate() when calling anonymousId() for the first time', async () => {
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 1 call to dispatchCreate (1 new server cookie)
+    await analytics.user().anonymousId()
+
+    expect(spyClear).toHaveBeenCalledTimes(0)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(1)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+  })
+
+  it('calls dispatchCreate() when calling track without a current user', async () => {
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 1 call to dispatchCreate through the anonymousId codepath
+    // we dont expect a userId cookie
+    await analytics.track('Checkout')
+
+    expect(spyClear).toHaveBeenCalledTimes(0)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(1)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+  })
+
+  it('calls dispatchCreate() when calling userId for the first time', async () => {
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 1 call to dispatchCreate through the userId codepath.
+    // we dont expect an anonymousId cookie.
+    await analytics.user().id('bob')
+
+    expect(spyClear).toHaveBeenCalledTimes(0)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(1)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+  })
+
+  it('calls dispatchCreate() when calling identify without a current user', async () => {
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // calling identify, means both anonymousId and userId are set
+    // through separate codepaths that *could* be called independently.
+    // therefore, we expect 2 calls to dispatchCreate.
+    await analytics.identify('123')
+
+    expect(spyClear).toHaveBeenCalledTimes(0)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(2)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+  })
+
+  it('calls no additional dispatchCreate()s when calling track with a current user', async () => {
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // calling identify, means both anonymousId and userId are set,
+    // therefore, we expect 2 calls to dispatchCreate (2 new server cookies)
+    await analytics.identify('123')
+
+    expect(spyClear).toHaveBeenCalledTimes(0)
+    expect(spyCreate).toHaveBeenCalledTimes(2)
+
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+
+    // we expect NO ADDITIONAL dispatchCreates or dispatchClears
+    await analytics.track('Checkout')
+
+    expect(spyClear).toHaveBeenCalledTimes(0)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(2)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+  })
+
+  it('calls dispatchClear() when manually clearing anonymousId()', async () => {
+    await analytics.user().anonymousId()
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 1 call to dispatchClear
+    await analytics.user().anonymousId(null)
+
+    expect(spyClear).toHaveBeenCalledTimes(1)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(0)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+  })
+
+  it('calls dispatchClear() when manually clearing userId()', async () => {
+    await analytics.user().id('bob')
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 1 call to dispatchClear
+    await analytics.user().id(null)
+
+    expect(spyClear).toHaveBeenCalledTimes(1)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(0)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+  })
+
+  it('calls dispatchClear() when reseting the user info', async () => {
+    await analytics.user().id('bob')
+    await analytics.user().anonymousId()
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 2 calls to dispatchClear
+    // we have to call separate codepaths for clearing anonymousId and userId
+    await analytics.reset()
+
+    expect(spyClear).toHaveBeenCalledTimes(2)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(0)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+  })
+
+  it('calls dispatchClear() when reseting the user info--even with no pre-existing user', async () => {
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 2 calls to dispatchClear
+    // we have to call separate codepaths for clearing anonymousId and userId
+    await analytics.reset()
+
+    expect(spyClear).toHaveBeenCalledTimes(2)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(0)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+  })
+
+  it('calls dispatch methods when changing the identity of a user', async () => {
+    await analytics.user().id('bob')
+    await analytics.user().anonymousId()
+    expect(analytics.storage.get('htjs_anonymous_id')).toBeTruthy()
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    // we expect 1 call to dispatchClear
+    // we expect 1 call to dispatchCreate
+    await analytics.user().id('tim')
+
+    expect(spyClear).toHaveBeenCalledTimes(1)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(1)
+    spyCreate.mockRestore()
+
+    // we expect that the dispatchClear comes before the dispatchCreate
+    await sleep(30).then(async () => {
+      // these are our last two dispatch calls (ignore setup stuff)
+      expect(fetchSpy.mock.calls[fetchSpy.mock.calls.length - 2]).toEqual([
+        'ht/cleartest',
+        expect.anything(),
+      ])
+      expect(fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1]).toEqual([
+        'ht/renewtest',
+        expect.anything(),
+      ])
+    })
+
+    expect(analytics.storage.get('htjs_user_id')).toBeTruthy()
+    // pre-existing behavior clears anonymousId when changing userId.
+    // can use analytics.alias('bob', 'tim') if customer-dev wants to workaround this
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe(null)
+  })
+
+  it('calls dispatchCreate() when migrating anonymousId from segment', async () => {
+    const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
+    const spyClear = jest.spyOn(cookieService, 'dispatchClear')
+
+    analytics.storage.set('ajs_anonymous_id', '456-789')
+    analytics.storage.set('ajs_user_id', 'timothy')
+
+    // we expect 1 call to dispatchCreate
+    await analytics.track('Checkout')
+
+    expect(spyClear).toHaveBeenCalledTimes(0)
+    spyClear.mockRestore()
+
+    expect(spyCreate).toHaveBeenCalledTimes(1)
+    spyCreate.mockRestore()
+
+    expect(analytics.storage.get('htjs_anonymous_id')).toBe('456-789')
+    // pre-existing behavior is to not migrate the userId
+    expect(analytics.storage.get('htjs_user_id')).toBe(null)
+
+    analytics.storage.clear('ajs_anonymous_id')
+    analytics.storage.clear('ajs_user_id')
+  })
+})

--- a/packages/browser/src/core/http-cookies/__tests__/index.test.ts
+++ b/packages/browser/src/core/http-cookies/__tests__/index.test.ts
@@ -198,7 +198,8 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
     const spyClear = jest.spyOn(cookieService, 'dispatchClear')
 
-    // we expect 1 call to dispatchCreate (1 new server cookie)
+    // we expect 1 call to dispatchCreate to create the anonymousId cookie
+    // we don't expect to set the userId cookie
     await analytics.user().anonymousId()
 
     expect(spyClear).toHaveBeenCalledTimes(0)
@@ -216,7 +217,7 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     const spyClear = jest.spyOn(cookieService, 'dispatchClear')
 
     // we expect 1 call to dispatchCreate through the anonymousId codepath
-    // we dont expect a userId cookie
+    // we dont expect to set a userId cookie
     await analytics.track('Checkout')
 
     expect(spyClear).toHaveBeenCalledTimes(0)
@@ -234,7 +235,7 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     const spyClear = jest.spyOn(cookieService, 'dispatchClear')
 
     // we expect 1 call to dispatchCreate through the userId codepath.
-    // we dont expect an anonymousId cookie.
+    // we dont expect to set an anonymousId cookie.
     await analytics.user().id('bob')
 
     expect(spyClear).toHaveBeenCalledTimes(0)
@@ -251,8 +252,8 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     const spyCreate = jest.spyOn(cookieService, 'dispatchCreate')
     const spyClear = jest.spyOn(cookieService, 'dispatchClear')
 
-    // calling identify, means both anonymousId and userId are set
-    // through separate codepaths that *could* be called independently.
+    // calling identify, means both anonymousId and userId are set.
+    // these are two separate codepaths (that *could* be called independently).
     // therefore, we expect 2 calls to dispatchCreate.
     await analytics.identify('123')
 
@@ -271,7 +272,7 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     const spyClear = jest.spyOn(cookieService, 'dispatchClear')
 
     // calling identify, means both anonymousId and userId are set,
-    // therefore, we expect 2 calls to dispatchCreate (2 new server cookies)
+    // therefore, we expect 2 calls to dispatchCreate (2 different code paths)
     await analytics.identify('123')
 
     expect(spyClear).toHaveBeenCalledTimes(0)
@@ -345,7 +346,7 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     const spyClear = jest.spyOn(cookieService, 'dispatchClear')
 
     // we expect 2 calls to dispatchClear
-    // we have to call separate codepaths for clearing anonymousId and userId
+    // we have to call both codepaths for clearing anonymousId and userId
     await analytics.reset()
 
     expect(spyClear).toHaveBeenCalledTimes(2)
@@ -366,7 +367,7 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     const spyClear = jest.spyOn(cookieService, 'dispatchClear')
 
     // we expect 2 calls to dispatchClear
-    // we have to call separate codepaths for clearing anonymousId and userId
+    // we have to call both codepaths for clearing anonymousId and userId
     await analytics.reset()
 
     expect(spyClear).toHaveBeenCalledTimes(2)
@@ -390,6 +391,7 @@ describe('Analytics - HTTPCookieService - Integration', () => {
 
     // we expect 1 call to dispatchClear
     // we expect 1 call to dispatchCreate
+    // they should happen in this order
     await analytics.user().id('tim')
 
     expect(spyClear).toHaveBeenCalledTimes(1)

--- a/packages/browser/src/core/http-cookies/index.ts
+++ b/packages/browser/src/core/http-cookies/index.ts
@@ -70,24 +70,24 @@ export class HTTPCookieService {
   }
 
   startQueueConsumer() {
-    if (!this.flushIntervalId) {
-      const bound = this.consumeQueue.bind(this)
-      this.flushIntervalId = setInterval(
-        () => bound().catch(console.error),
-        this.flushInterval
-      )
+    if (this.flushIntervalId) {
+      console.error('HTTPCookie queue consumer is already running.')
       return
     }
-    console.error('HTTPCookie queue consumer is already running.')
+    const bound = this.consumeQueue.bind(this)
+    this.flushIntervalId = setInterval(
+      () => bound().catch(console.error),
+      this.flushInterval
+    )
   }
 
   stopQueueConsumer() {
-    if (this.flushIntervalId) {
-      clearInterval(this.flushIntervalId)
-      this.flushIntervalId = undefined
+    if (!this.flushIntervalId) {
+      console.error('HTTPCookie queue consumer is already stopped.')
       return
     }
-    console.error('HTTPCookie queue consumer is already stopped.')
+    clearInterval(this.flushIntervalId)
+    this.flushIntervalId = undefined
   }
 
   private sendHTTPCookies(serviceUrl: string): DeferredRequest {

--- a/packages/browser/src/core/http-cookies/index.ts
+++ b/packages/browser/src/core/http-cookies/index.ts
@@ -1,0 +1,152 @@
+import { fetch } from '../../lib/fetch'
+
+type DeferredRequest = () => Promise<Response>
+
+export type HTTPCookieServiceOptions = {
+  renewUrl: string
+  clearUrl: string
+  retries?: number
+  backoff?: number
+  flushInterval?: number
+}
+
+/**
+ * `HTTPCookieService.load(...)` should be awaited inside `loadAnalytics(...)`.
+ * If the server can recreate an expired "Browser Cookie", by inspecting existing
+ * "Server Cookies", we should delay dispatching events until receiving the Cookie.
+ *
+ *  dispatch$Method class methods should be used after any cookie interactions:
+ * `dispatchCreate()` should be called after creating any new browser cookies.
+ * `dispatchClear()` should be called after clearing any browser cookies.
+ *
+ * Manual `startQueueConsumer()` or `stopQueueConsumer()` is not usually necessary.
+ *
+ * Glossary:
+ * "Server Cookies": `HTTPOnly:true`, stored on client, but only server can access.
+ * "Browser Cookies": `HTTPOnly:false`, stored on client, and both client and server can access.
+ */
+export class HTTPCookieService {
+  private queue: DeferredRequest[]
+  private renewUrl: string
+  private clearUrl: string
+  private retries: number
+  private backoff: number
+  private flushInterval: number
+  private flushIntervalId?: NodeJS.Timer
+
+  private constructor(options: HTTPCookieServiceOptions) {
+    this.renewUrl = options.renewUrl
+    this.clearUrl = options.clearUrl
+    this.backoff = options.backoff ?? 300
+    this.retries = options.retries ?? 3
+    this.flushInterval = options.flushInterval ?? 1000
+    this.queue = []
+  }
+
+  static async load(
+    options: HTTPCookieServiceOptions
+  ): Promise<HTTPCookieService> {
+    const cookieService = new HTTPCookieService(options)
+
+    // renew any existing HTTPCookies already on the device
+    // we want `load()` to block on this, so await directly instead of calling dispatch
+    const req = cookieService.sendHTTPCookies(options.renewUrl)
+    await retry(req, cookieService.retries, cookieService.backoff).catch(
+      console.error
+    )
+
+    // consume HTTPCookie actions, sequentially, as needed
+    cookieService.startQueueConsumer()
+
+    return cookieService
+  }
+
+  dispatchCreate() {
+    this.queue.push(this.sendHTTPCookies(this.renewUrl))
+  }
+
+  dispatchClear() {
+    this.queue.push(this.sendHTTPCookies(this.clearUrl))
+  }
+
+  startQueueConsumer() {
+    if (!this.flushIntervalId) {
+      const bound = this.consumeQueue.bind(this)
+      this.flushIntervalId = setInterval(
+        () => bound().catch(console.error),
+        this.flushInterval
+      )
+      return
+    }
+    console.error('HTTPCookie queue consumer is already running.')
+  }
+
+  stopQueueConsumer() {
+    if (this.flushIntervalId) {
+      clearInterval(this.flushIntervalId)
+      this.flushIntervalId = undefined
+      return
+    }
+    console.error('HTTPCookie queue consumer is already stopped.')
+  }
+
+  private sendHTTPCookies(serviceUrl: string): DeferredRequest {
+    return async function (): Promise<Response> {
+      return await fetch(serviceUrl, {
+        credentials: 'include',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        method: 'post',
+        body: JSON.stringify({
+          sentAt: new Date().toISOString(),
+        }),
+      })
+    }
+  }
+
+  /**
+   * This queue exists to avoid race conditions.
+   *
+   * Customer-developers may not `await` all promises.
+   *
+   * Therefore, introducing async code into analytics.track(), etc
+   * could create race conditions in customer code.
+   *
+   * The queue enforces: if someone calls analytics.clear()
+   * before calling analytics.identify(), the cookie service
+   * will consume those actions, sequentially, even if no promises
+   * are awaited.
+   */
+  private async consumeQueue() {
+    while (this.queue.length > 0) {
+      const req = this.queue.shift() as DeferredRequest
+      await retry(req, this.retries, this.backoff).catch(console.error)
+    }
+  }
+}
+
+async function sleep(delayMS: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMS))
+}
+
+async function retry(
+  req: DeferredRequest,
+  retries: number,
+  backoff: number
+): Promise<Response> {
+  while (retries >= 0) {
+    try {
+      return await req().then((res) => {
+        if (res.ok) return res
+        throw new Error(`Status: ${res.status} ${res.statusText}`)
+      })
+    } catch (error) {
+      retries -= 1
+      if (retries <= 0) throw error
+      await sleep(backoff)
+    }
+  }
+  throw Error('HtEvents: Problem with DeferredRequest')
+}

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -32,6 +32,10 @@ export interface UserOptions {
   disable?: boolean
   localStorageFallbackDisabled?: boolean
   persist?: boolean
+
+  /**
+   * Replicates "BrowserCookie" actions against a matching "ServerCookie".
+   */
   httpCookieService?: HTTPCookieService
 
   cookie?: {

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -153,7 +153,7 @@ export class User {
     if (id !== undefined) {
       const clearingIdentity = id === null
       const changingIdentity = id !== prevId && prevId !== null && id !== null
-      const creatingIdentity = id !== prevId && prevId == null && id !== null
+      const creatingIdentity = id !== prevId && prevId === null && id !== null
 
       this.identityStore.set(this.idKey, id)
 

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -21,6 +21,7 @@ import {
   hasSessionExpired,
   updateSessionExpiration,
 } from '../session'
+import type { HTTPCookieService } from '../http-cookies'
 
 export type ID = string | null | undefined
 
@@ -31,6 +32,7 @@ export interface UserOptions {
   disable?: boolean
   localStorageFallbackDisabled?: boolean
   persist?: boolean
+  httpCookieService?: HTTPCookieService
 
   cookie?: {
     key?: string
@@ -145,11 +147,22 @@ export class User {
     const prevId = this.identityStore.getAndSync(this.idKey)
 
     if (id !== undefined) {
+      const clearingIdentity = id === null
+      const changingIdentity = id !== prevId && prevId !== null && id !== null
+      const creatingIdentity = id !== prevId && prevId == null && id !== null
+
       this.identityStore.set(this.idKey, id)
 
-      const changingIdentity = id !== prevId && prevId !== null && id !== null
+      if (clearingIdentity) {
+        this.options?.httpCookieService?.dispatchClear()
+      }
+
       if (changingIdentity) {
-        this.anonymousId(null)
+        this.anonymousId(null) // this also runs dispatchClear()
+      }
+
+      if (changingIdentity || creatingIdentity) {
+        this.options?.httpCookieService?.dispatchCreate()
       }
     }
 
@@ -176,26 +189,34 @@ export class User {
 
     if (id === undefined) {
       let val = this.identityStore.getAndSync(this.anonKey)
+      let migrated = false
 
       // support anonymousId migration from other analytics providers
       if (!val) {
         val = decryptRudderHtValue(
           this.identityStore.getAndSync(rudderHtAnonymousIdKey) ?? ''
         )
+        migrated = Boolean(val)
         if (val) this.identityStore.set(this.anonKey, val)
       }
       if (!val) {
         val = this.identityStore.getAndSync(segmentAnonymousIdKey)
+        migrated = Boolean(val)
         if (val) this.identityStore.set(this.anonKey, val)
       }
       if (!val) {
         val = decryptRudderValue(
           this.identityStore.getAndSync(rudderAnonymousIdKey) ?? ''
         )
+        migrated = Boolean(val)
         if (val) this.identityStore.set(this.anonKey, val)
       }
       if (!val) {
         val = this.legacySIO()?.[0] ?? null
+      }
+
+      if (migrated) {
+        this.options?.httpCookieService?.dispatchCreate()
       }
 
       if (val) {
@@ -205,11 +226,16 @@ export class User {
 
     if (id === null) {
       this.identityStore.set(this.anonKey, null)
-      return this.identityStore.getAndSync(this.anonKey)
+      const clearedVal = this.identityStore.getAndSync(this.anonKey)
+      this.options?.httpCookieService?.dispatchClear()
+      return clearedVal
     }
 
     this.identityStore.set(this.anonKey, id ?? uuid())
-    return this.identityStore.getAndSync(this.anonKey)
+    const syncedVal = this.identityStore.getAndSync(this.anonKey)
+
+    this.options?.httpCookieService?.dispatchCreate()
+    return syncedVal
   }
 
   traits = (traits?: Traits | null): Traits | undefined => {


### PR DESCRIPTION
See the added README.md file for the most context.

I included the server example in a new README.md file next to the HTTPCookieService code. I'm not sure that's the best place, but it doesn't seem to warrant it's own repo or package either. It's only relevant to the web SDK. I didn't want to include the actual server here (e.g. it's own package.json and run commands), since that might confuse our build steps. I'm open to making it a new top level package and just linking from the new `README.md` doc.

LMK if that sounds better.