### PR TITLE
Fix http cookie path

### DIFF
--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -363,7 +363,7 @@ async function loadAnalytics(
   if (!options.disableClientPersistence && options.httpCookieServiceOptions) {
     options.httpCookieService = await HTTPCookieService.load(
       options.httpCookieServiceOptions
-    )
+    ).catch((err): undefined => console.error(err) as undefined)
   }
 
   const opts: InitOptions = { retryQueue, ...options }

--- a/packages/browser/src/core/http-cookies/__tests__/index.test.ts
+++ b/packages/browser/src/core/http-cookies/__tests__/index.test.ts
@@ -13,55 +13,34 @@ describe('HTTPCookieService', () => {
     // if the user passes a slash prefix
     expect(
       HTTPCookieService.urlHelper({
-        origin: 'http://localhost:8080/',
-        renewUrl: '/renew',
-        clearUrl: '/clear',
-      }).renewUrl
-    ).toEqual('http://localhost:8080/renew')
-
-    // if the user passes no slash prefix
-    expect(
-      HTTPCookieService.urlHelper({
-        origin: 'http://localhost:8080/',
-        renewUrl: 'renew',
-        clearUrl: 'clear',
-      }).renewUrl
-    ).toEqual('http://localhost:8080/renew')
-
-    // if the user omits all slashes
-    expect(
-      HTTPCookieService.urlHelper({
-        origin: 'http://localhost:8080',
-        renewUrl: 'renew',
-        clearUrl: 'clear',
-      }).renewUrl
-    ).toEqual('http://localhost:8080/renew')
-
-    // if the user passes a full URL to the renewUrl, that will be used as the renewUrl
-    expect(
-      HTTPCookieService.urlHelper({
-        origin: 'http://localhost:8080/',
-        renewUrl: 'http://localhost:808/renew',
-        clearUrl: '/clear',
-      }).renewUrl
-    ).toEqual('http://localhost:808/renew')
-
-    // if the user omits origin
-    expect(
-      HTTPCookieService.urlHelper({
         renewUrl: '/renew',
         clearUrl: '/clear',
       }).renewUrl
     ).toEqual('http://localhost/renew')
 
-    // if the user passes an invalid origin (e.g. omits http scheme), throw error
-    expect(() => {
+    // if the user passes no slash prefix
+    expect(
       HTTPCookieService.urlHelper({
-        origin: 'localhost:8080/',
-        renewUrl: '/renew',
+        renewUrl: 'renew',
+        clearUrl: 'clear',
+      }).renewUrl
+    ).toEqual('http://localhost/renew')
+
+    // if the user omits all slashes
+    expect(
+      HTTPCookieService.urlHelper({
+        renewUrl: 'renew',
+        clearUrl: 'clear',
+      }).renewUrl
+    ).toEqual('http://localhost/renew')
+
+    // if the user passes a full URL to the renewUrl, that will be used as the renewUrl
+    expect(
+      HTTPCookieService.urlHelper({
+        renewUrl: 'http://localhost:808/renew',
         clearUrl: '/clear',
       }).renewUrl
-    }).toThrow('Invalid URL: /renew')
+    ).toEqual('http://localhost:808/renew')
   })
 
   it('renews cookie on load', async () => {
@@ -303,16 +282,14 @@ describe('Analytics - HTTPCookieService - Integration', () => {
   })
 
   it('does not stop normal functioning on wrong url', async () => {
-    // this will console.error the bad origin URL
-    // this will NOT throw an error
+    // this will not throw an error
     new Analytics(
       {
         writeKey: 'abc',
       },
       {
         httpCookieServiceOptions: {
-          origin: 'localhost:8080/',
-          renewUrl: 'ht/renewtest',
+          renewUrl: 'http::invalid://ht/renewtest',
           clearUrl: 'ht/cleartest',
         },
       }

--- a/packages/browser/src/core/http-cookies/index.ts
+++ b/packages/browser/src/core/http-cookies/index.ts
@@ -5,7 +5,6 @@ type DeferredRequest = () => Promise<Response>
 export type HTTPCookieServiceOptions = {
   renewUrl: string
   clearUrl: string
-  origin?: string
   retries?: number
   backoff?: number
   flushInterval?: number
@@ -47,13 +46,11 @@ export class HTTPCookieService {
   }
 
   static urlHelper(options: HTTPCookieServiceOptions): {
-    origin: string
     renewUrl: string
     clearUrl: string
   } {
-    const origin = options.origin ?? window.location.origin
+    const origin = window.location.origin
     return {
-      origin,
       renewUrl: new URL(options.renewUrl, origin).href,
       clearUrl: new URL(options.clearUrl, origin).href,
     }

--- a/packages/browser/src/core/http-cookies/index.ts
+++ b/packages/browser/src/core/http-cookies/index.ts
@@ -51,7 +51,7 @@ export class HTTPCookieService {
     renewUrl: string
     clearUrl: string
   } {
-    const origin = options.origin ?? new URL(window.location.href).origin
+    const origin = options.origin ?? window.location.origin
     return {
       origin,
       renewUrl: new URL(options.renewUrl, origin).href,

--- a/packages/browser/src/generated/version.ts
+++ b/packages/browser/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.1.0'
+export const version = '1.2.0'


### PR DESCRIPTION
Fix for bug introduced in the previous PR https://github.com/ht-sdks/events-sdk-js-mono/pull/6. 

The "Renew URL" is being passed as a path to the SDK e.g. "/ht/renew". The assumption was that this is called against the domain -> e.g. if I'm on example.com, then call example.com/ht/renew. However, there was a bug where if I was on example.com/home it would call example.com/home/ht/renew. So the fix is to calculate the absolute URL instead of calling the relative path URL.