### PR TITLE
Cookie local storage sync

### DIFF
--- a/packages/browser/src/core/http-cookies/__tests__/index.test.ts
+++ b/packages/browser/src/core/http-cookies/__tests__/index.test.ts
@@ -281,6 +281,11 @@ describe('Analytics - HTTPCookieService - Integration', () => {
     analytics.storage.clear('htjs_user_id')
   })
 
+  afterEach(async () => {
+    analytics.storage.clear('htjs_anonymous_id')
+    analytics.storage.clear('htjs_user_id')
+  })
+
   it('does not stop normal functioning on wrong url', async () => {
     // this will not throw an error
     new Analytics(

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -140,6 +140,14 @@ export class User {
       legacyUser.id && this.id(legacyUser.id)
       legacyUser.traits && this.traits(legacyUser.traits)
     }
+
+    // HTTPCookies require that localStorage values be synced to cookies
+    if (this.options.httpCookieService) {
+      this.identityStore.getAndSync(this.anonKey)
+      this.identityStore.getAndSync(this.idKey)
+      this.options.httpCookieService?.dispatchCreate()
+    }
+
     autoBind(this)
   }
 

--- a/packages/browser/src/core/user/tld.ts
+++ b/packages/browser/src/core/user/tld.ts
@@ -1,4 +1,4 @@
-import cookie from 'js-cookie'
+import cookie, { CookieAttributes } from 'js-cookie'
 
 /**
  * Levels returns all levels of the given url.
@@ -45,11 +45,15 @@ export function tld(url: string): string | undefined {
 
   const lvls = levels(parsedUrl)
 
-  // Lookup the real top level one.
+  // Test for the top most domain that the browser allows
   for (let i = 0; i < lvls.length; ++i) {
-    const cname = '__tld__'
+    const cname = Math.round(Math.random() * 10_000).toString()
     const domain = lvls[i]
-    const opts = { domain: '.' + domain }
+    const opts = {
+      domain: '.' + domain,
+      path: '/',
+      sameSite: 'Lax',
+    } as CookieAttributes
 
     try {
       // cookie access throw an error if the library is ran inside a sandboxed environment (e.g. sandboxed iframe)


### PR DESCRIPTION
Mac's flagship browser doesn't allow top level domain cookies to be set when on a subdomain.

All of this had to be tested in the real browser on a real internet domain. I couldn't write browser-specific unit tests. For testing, I mostly made commits locally and pushed tags to create "release candidates" on our CDN.

Because of the lack of testability, I've tried to document my testing below.

# Part 1 - proving the bug
This is a problem because the SDK defaults the cookie domain to the top level domain, even if the page is on a subdomain.
e.g. `amazonaws.com` even if the page is `q8t1vv5kz5.execute-api.us-east-2.amazonaws.com`. The result of this is that the browser then silently "rejects" setting cookies for that top level domain. The impact is normally low, because the SDK defaults to using localStorage over cookies. It's also normally low, since it doesn't happen on other browsers, like Chrome.

**However, the impact is high when using HTTPCookies https://github.com/ht-sdks/events-sdk-js-mono/pull/6, since that feature specifically requires browser Cookies in order to fetch server cookies.** If there are no browser cookies, there can't be server cookies.

Here's a short test of the bug:
```
// delete cookies and localStorage
htevents.storage.stores[0].set('htjs_anonymous_id', '1'); // localStorage
htevents.storage.stores[0].get('htjs_anonymous_id'); // localStorage
> '1'
htevents.storage.stores[1].options.domain = ".amazonaws.com"; // cookies
htevents.storage.stores[1].set('htjs_anonymous_id', '1'); // cookies
htevents.storage.stores[1].get('htjs_anonymous_id'); // cookies
> null
htevents.storage.stores[1].options.domain = "amazonaws.com"; // cookies
htevents.storage.stores[1].set('htjs_anonymous_id', '1'); // cookies
htevents.storage.stores[1].get('htjs_anonymous_id'); // cookies
> null
htevents.storage.stores[1].options.domain = "q8t1vv5kz5.execute-api.us-east-2.amazonaws.com"; // cookies
htevents.storage.stores[1].set('htjs_anonymous_id', '1'); // cookies
htevents.storage.stores[1].get('htjs_anonymous_id'); // cookies
> 1
```

This then led to the realization that it could be worked around by setting the Domain to something the browser would actually accept:
```
e.load('a7ca582a93143227a2662c7120ecc6752591ea788fc83b4ac5a06b179fc1119b',{
  apiHost:'us-east-1.hightouch-events.com',
  httpCookieServiceOptions: {clearUrl: 'default/ht/clear', renewUrl: 'default/ht/renew', backoff: 5000},
  cookie: {
    domain: "q8t1vv5kz5.execute-api.us-east-2.amazonaws.com",
  }
}),
```

This, however, isn't idiot proof. Instead, the SDK should be able to determine the right Domain to use.

# Part 2 - finding the bug

The SDK actually already attempted to determine the best domain to use. https://github.com/ht-sdks/events-sdk-js-mono/blob/master/packages/browser/src/core/storage/cookieStorage.ts#L18L28
```
export class CookieStorage<Data extends StorageObject = StorageObject>
  implements Store<Data>
{
  static get defaults(): CookieOptions {
    return {
      maxage: ONE_YEAR,
      domain: tld(window.location.href),
      path: '/',
      sameSite: 'Lax',
    }
  }
```
It passed the webpage URL to a function called `tld()`. This function split the URL into a list of domain levels from **most permissive** to **least permissive** (e.g. `[amazonaws.com, us-east-2.amazonaws.com, execute-api.us-east-2.amazonaws.com, q8t1vv5kz5.execute-api.us-east-2.amazonaws.com]`). It's in the SDK's interest to get the most permissive cookie domain possible, so that tracking can work across subdomains.

The function then looped through these domains and "tested" whether the browser would let us set a cookie named `_TLD_` with a value of `1`, while using these domains for the cookie's `Domain` field. Once we found a domain that worked, we'd stop and use that domain for our other cookies, e.g. `htjs_anonymous_id`.

```
  for (let i = 0; i < lvls.length; ++i) {
    const cname = '__tld__'
    const domain = lvls[i]
    const opts = { domain: '.' + domain }

    try {
      cookie.set(cname, '1', opts)
      if (cookie.get(cname)) {
        cookie.remove(cname, opts)
        return domain
      }
```

The bug is that this function was determining `amazonaws.com` as a suitable domain, despite the SDK not being able to set any _other_ cookies on that domain.

# Part 3 - Fixing the bug

Browser's care about the cookie options. We were testing the cookie while only setting `Domain`, but then we were trying to use the cookie while setting `Domain`, `sameSite`, etc. I changed this to be at parity with our needs, and added logging so I could see which cookies were returning values after being set:
```
Domain: amazonaws.com, Key: "__tld__", Value: undefined
Domain: us-east-2.amazonaws.com, Key: "__tld__", Value: undefined
Domain: execute-api.us-east-2.amazonaws.com, Key: "__tld__", Value: undefined
Domain: q8t1vv5kz5.execute-api.us-east-2.amazonaws.com, Key: "__tld__", Value: 1
```

That looked like things were working. However, running the tld function **multiple times** would eventually log this:
```
Domain: amazonaws.com, Key: "__tld__", Value: 1
```

This isn't "true" though. The browser still wouldn't allow us to set any **other** cookies on amazonaws.com! So the tld "test" function was a "liar". It could be a browser engaging in defensive measures, or it could be a browser caching bug for cookie access. **In either case, this was fixed by changing our "test" cookie name to `Math.random()` based values.** 

# Part 4 - More Fixes

The browser could now set cookies correctly. I could delete all cookies and localStorage, then load the SDK, and then find browser cookies in the console.

However, if I deleted cookies, but left localStorage, the cookies would not populate. This is a problem since someone might be migrating their SDK usage from localStorage to HTTPCookies. This is also a problem since it leaves our browser out of alignment (on Chrome, I could delete cookies and watch as the localStorage values would sync over).

The solution was to add a deliberate `getAndSync()` call in the initialization of the User class. This ensures that any values in localStorage get synced to Cookies, before the SDK fully initializes. Unfortunately, it happens after HTTPCookieService initializes, so we had to add a deliberate call to HTTPCookieService.dispatchCreate().