### PR TITLE
update deploy scripts for parity with deploy template

### DIFF
--- a/.github/workflows/deploy-browser-cdn-candidate.yml
+++ b/.github/workflows/deploy-browser-cdn-candidate.yml
@@ -20,34 +20,33 @@ jobs:
     name: Deploy to CDN
     runs-on: ubuntu-latest
     steps:
-      - name: Get tag version
-        id: get_tag_version
-        env:
-          TAG: ${{ github.ref_name }}
-        run: echo "PATH_VERSION=${TAG##browser@}" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_PROD_ACCOUNT_ID }}:role/${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
           aws-region: us-east-1
 
-      - name: Checkout source branch
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
       - name: Install dependencies
-        run: |
-          npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
+
+      - name: Parse version
+        id: parse_version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: echo "VERSION=${TAG##browser@}" >> $GITHUB_OUTPUT
+
+      - name: Set version
+        working-directory: packages/browser
+        run: npm version ${{ steps.parse_version.outputs.VERSION }} --allow-same-version --no-commit-hooks --no-git-tag-version
 
       - name: Release to CDN
-        env:
-          PATH_VERSION: '${{ steps.get_tag_version.outputs.PATH_VERSION }}'
         working-directory: packages/browser
-        run: |
-          npm run candidate:cdn
+        env:
+          PATH_VERSION: ${{ steps.parse_version.outputs.VERSION }}
+        run: npm run candidate:cdn

--- a/.github/workflows/deploy-releases.yml
+++ b/.github/workflows/deploy-releases.yml
@@ -22,68 +22,47 @@ jobs:
     secrets: inherit
 
   deploy-browser:
-    if: "startsWith( github.ref_name, 'browser@' )"
-    name: Deploy Browser to NPM and CDN
+    if: ${{ startsWith(github.event.release.tag_name, 'browser') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source branch
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Get tag version
-        id: get_tag_version
-        env:
-          TAG: ${{ github.ref_name }}
-        run: echo "PATH_VERSION=${TAG##browser@}" >> $GITHUB_OUTPUT
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org
+          node-version-file: .nvmrc
+          cache: 'npm'
 
-      - name: Get package version
-        id: get_package_version
-        run: echo "PACKAGE_VERSION=$(jq -r '.version' < ./packages/browser/package.json)" >> $GITHUB_OUTPUT
-
-      - name: Check package.json version
-        shell: bash
-        env:
-          PATH_VERSION: '${{ steps.get_tag_version.outputs.PATH_VERSION }}'
-          PACKAGE_VERSION: '${{ steps.get_package_version.outputs.PACKAGE_VERSION }}'
-        run: |
-          node -e 'process.env.PATH_VERSION === process.env.PACKAGE_VERSION ? process.exit() : process.exit(1)'
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_PROD_ACCOUNT_ID }}:role/${{ secrets.AWS_PROD_S3_SYNC_ROLE }}
           aws-region: us-east-1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          registry-url: https://registry.npmjs.org
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Build
+      - name: Parse version
+        id: parse_version
         env:
-          PATH_VERSION: '${{ steps.get_tag_version.outputs.PATH_VERSION }}'
-        working-directory: packages/browser
-        run: |
-          npx turbo run build
+          TAG: ${{ github.event.release.tag_name }}
+        run: echo "VERSION=${TAG##browser@}" >> $GITHUB_OUTPUT
 
-      - name: Release browser to CDN
-        env:
-          PATH_VERSION: '${{ steps.get_tag_version.outputs.PATH_VERSION }}'
+      - name: Set version
         working-directory: packages/browser
-        run: |
-          npm run release:cdn
+        run: npm version ${{ steps.parse_version.outputs.VERSION }} --allow-same-version --no-commit-hooks --no-git-tag-version
 
-      - name: Publish browser package to NPM
+      - name: Release to CDN
+        working-directory: packages/browser
         env:
-          HUSKY: 0
+          PATH_VERSION: ${{ steps.parse_version.outputs.VERSION }}
+        run: npm run release:cdn
+
+      - name: Publish to NPM
+        working-directory: packages/browser
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        working-directory: packages/browser
-        run: |
-          npm publish --access=public
+          HUSKY: 0
+        run: npm publish --access=public
 
   deploy-node:
     uses: ./.github/workflows/deploy-npm.template.yml


### PR DESCRIPTION
Will test with candidate CDN build before creating release.

This should also fix the error here: https://github.com/ht-sdks/events-sdk-js-mono/actions/runs/8650931587/job/23720485544