### PR TITLE
Remove peer deps from consent-wrapper-onetrust

### DIFF
--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -32,14 +32,6 @@
   "dependencies": {
     "@ht-sdks/events-sdk-js-consent-tools": "^1.0.0"
   },
-  "peerDependencies": {
-    "@ht-sdks/events-sdk-js-browser": "^1.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@ht-sdks/events-sdk-js-browser": {
-      "optional": true
-    }
-  },
   "license": "MIT",
   "repository": {
     "directory": "packages/consent/consent-wrapper-onetrust",


### PR DESCRIPTION
Since `consent-tools` already specifies a peer dependency on `events-sdk-js-browser` it is redundant to do so in `consent-wrapper-onetrust` (since the wrapper just forwards the analytics instance to `consent-tools`).

It is causing a build error when trying to set the browser SDK version to an RC like `browser@1.3.0-ga4` via `npm version`. 

By removing the additional peer dependency from `consent-wrapper-onetrust` things work smoothly.