### PR TITLE
Fix `webpackChunkName` for Google Tag Manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22106,14 +22106,6 @@
       "devDependencies": {
         "@internal/config-webpack": "*",
         "@internal/test-helpers": "*"
-      },
-      "peerDependencies": {
-        "@ht-sdks/events-sdk-js-browser": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@ht-sdks/events-sdk-js-browser": {
-          "optional": true
-        }
       }
     },
     "packages/core": {

--- a/packages/browser/src/plugins/destinations/index.ts
+++ b/packages/browser/src/plugins/destinations/index.ts
@@ -11,7 +11,7 @@ export async function createDestination(
   switch (name) {
     case 'Google Tag Manager':
       return import(
-        /* webpackChunkName: "destinations/google-tag-manager" */ './google-tag-manager'
+        /* webpackChunkName: "google-tag-manager" */ './google-tag-manager'
       ).then((mod) => mod.default(settings as any))
     default:
       return undefined


### PR DESCRIPTION
Using a `webpackChunkName` that contains nested directories like:
```js
return import(
  /* webpackChunkName: "destinations/google-tag-manager" */ './google-tag-manager'
).then((mod) => mod.default(settings as any))
```

is not supported by the `release.js` script.