### PR TITLE
Fix session expiration refresh logic

### DIFF
--- a/packages/browser/src/core/session/__tests__/index.test.ts
+++ b/packages/browser/src/core/session/__tests__/index.test.ts
@@ -5,6 +5,16 @@ import {
 } from '..'
 
 describe('()', () => {
+  const now = Date.now()
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(now)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   it('hasSessionExpired', () => {
     const past = Date.now() - 10000
     expect(hasSessionExpired(past)).toEqual(true)
@@ -27,13 +37,13 @@ describe('()', () => {
     expect(
       updateSessionExpiration({
         autoTrack: true,
-        expiresAt: 10,
+        expiresAt: now,
         timeout: 15,
         sessionStart: false,
       })
     ).toEqual({
       autoTrack: true,
-      expiresAt: 25,
+      expiresAt: now + 15,
       timeout: 15,
       sessionStart: false,
     })

--- a/packages/browser/src/core/session/index.ts
+++ b/packages/browser/src/core/session/index.ts
@@ -101,7 +101,8 @@ export const generateManualTrackingSession = (id?: number): SessionInfo => {
 export const updateSessionExpiration = (session: SessionInfo): SessionInfo => {
   session.sessionStart = false
   if (session.autoTrack) {
-    session.expiresAt = session.expiresAt! + session.timeout!
+    // extend session by `timeout`
+    session.expiresAt = Date.now() + session.timeout!
   }
   return session
 }

--- a/packages/browser/src/core/user/__tests__/session.test.ts
+++ b/packages/browser/src/core/user/__tests__/session.test.ts
@@ -11,6 +11,8 @@ function clear(): void {
   localStorage.clear()
 }
 
+const now = Date.now()
+
 let store: LocalStorage
 beforeEach(function () {
   store = new LocalStorage()
@@ -18,6 +20,13 @@ beforeEach(function () {
   // Restore any cookie, localstorage disable
   jest.restoreAllMocks()
   jest.spyOn(console, 'warn').mockImplementation(() => {}) // silence console spam.
+
+  // mock system time
+  jest.useFakeTimers().setSystemTime(now)
+})
+
+afterEach(() => {
+  jest.useRealTimers()
 })
 
 const seshKey = 'htjs_sesh'
@@ -46,7 +55,7 @@ describe('user anonymousId migration', () => {
       const updatedSesh = store.get(seshKey) as unknown as SessionInfo
       expect(updated?.sessionStart).toEqual(undefined)
       expect(updated?.sessionId).toEqual(session?.sessionId)
-      expect(updatedSesh.expiresAt).toEqual(sesh.expiresAt! + sesh.timeout!)
+      expect(updatedSesh.expiresAt).toEqual(now + sesh.timeout!)
     })
 
     it('should not create a session if autoTrack is disabled', () => {

--- a/packages/browser/src/core/user/__tests__/session.test.ts
+++ b/packages/browser/src/core/user/__tests__/session.test.ts
@@ -44,6 +44,17 @@ describe('user anonymousId migration', () => {
       expect(sesh.autoTrack).toBeTruthy()
     })
 
+    it('should refresh expiration on session update', () => {
+      const user = new User()
+      user.getAndUpdateSession()
+      const sesh = store.get(seshKey) as unknown as SessionInfo
+      expect(sesh.expiresAt).toEqual(now + sesh.timeout!)
+      // subsequent calls should refresh the expiration relative to `now`
+      user.getAndUpdateSession()
+      const updatedSesh = store.get(seshKey) as unknown as SessionInfo
+      expect(updatedSesh.expiresAt).toEqual(now + sesh.timeout!)
+    })
+
     it('should update an existing session', () => {
       const user = new User()
       const session = user.getAndUpdateSession()


### PR DESCRIPTION
https://hightouchexternal.slack.com/archives/C07JR9JD58Q/p1725560547073239

There's a bug in our session refresh logic, we currently extend the expiration every time a user interacts with the SDK, but when doing so we extend the existing expiration by the session `timeout`, rather than setting the expiration relative to `now()` + `timeout`. This means with a 4h timeout, if I interact with the page 5x in rapid succession, the expiration will be 20h from now.