### PR TITLE
Change InitOptions default from batching=true to batching=false

### DIFF
--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -316,8 +316,7 @@ const defaultHightouchIntegration: HightouchioSettings = {
   addBundledMetadata: false,
   maybeBundledConfigIds: {},
   deliveryStrategy: {
-    strategy: 'batching',
-    config: { timeout: 1000, size: 10 }, // 1 second or 10 items
+    strategy: 'standard',
   },
 }
 
@@ -353,13 +352,14 @@ async function loadAnalytics(
       ...(settings.writeKey ? { apiKey: settings.writeKey } : {}),
       ...(options.apiHost ? { apiHost: options.apiHost } : {}),
       ...(options.protocol ? { protocol: options.protocol } : {}),
-      // defaultHightouchIntegration defaults to 'batching'
-      // allow the options override to turn it off
-      ...(options.batching == false
+      // defaultHightouchIntegration defaults to 'standard'
+      // allow a simple options override to turn on 'batching'
+      ...(options.batching == true
         ? {
             deliveryStrategy: {
-              strategy: 'standard',
-            },
+              strategy: 'batching',
+              config: { timeout: 1000, size: 10 }, // 1 second or 10 items
+            } as HightouchioSettings["deliveryStrategy"],
           }
         : {}),
     }

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -359,7 +359,7 @@ async function loadAnalytics(
             deliveryStrategy: {
               strategy: 'batching',
               config: { timeout: 1000, size: 10 }, // 1 second or 10 items
-            } as HightouchioSettings["deliveryStrategy"],
+            } as HightouchioSettings['deliveryStrategy'],
           }
         : {}),
     }

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -153,7 +153,7 @@ export interface InitOptions {
    */
   apiHost?: string // Defaults to us-east-1.hightouch-events.com
   protocol?: string // Defaults to https
-  batching?: boolean // Defaults to true
+  batching?: boolean // Defaults to false
 }
 
 /* analytics-classic stubs */


### PR DESCRIPTION
### Changes

The following code will no longer enable batching by default.
```
export const htevents = HtEventsBrowser.load(
  {
    writeKey: <WRITE_KEY>,
  },
  { 
     apiHost: "us-east-1.hightouch-events.com",
  },
);
```

You will now need to pass this
```
export const htevents = HtEventsBrowser.load(
  {
    writeKey: <WRITE_KEY>,
  },
  { 
     apiHost: "us-east-1.hightouch-events.com",
     batching: true
  },
);
```

Or this
```
<script type="text/javascript">
// omitted for brevity
...
e.load(<WRITE_KEY>,{apiHost:'us-east-1.hightouch-events.com', batching: true}),
e.page()}}();
</script>
```

### Context

This SDK being forked from Seg, the original default behavior was to send events to the server, one at a time, as they became available. The original code also had an option to enable batching, where batches would be sent to the server every XYZ seconds or XYZ number of events. 

In theory, batching is better and can save browser CPU when a website is sending many events. Therefore, last year, we switched the SDK to enable batching by default. In retrospect, that was a mistake.

### Why

In practice, if you set up two SDKs--one using batching and one not--the `sentAt` timestamps will look different. This then may lead to final `timestamp` being clock-skew-adjusted different. This makes it harder to compare and cross reference two SDKs processing the same events on the same website. This then makes it harder to potentially switch from one SDK to the other. If we set our default to be the same as the other SDK's default, comparisons will be more straight forward. Future data will be more like past data, there will be less surprises, and migrations will be easier.

### Testing

- Unit tests passing
- Manual testing with https://cdn.hightouch-events.com/browser/candidate/1.4.0-rc/events.min.js and the CDN snippet. Snippet respects `batching: true`, `batching: false`, and behaves like `batching: false` when omitted.
