### PR TITLE
Facebook Parameters plugin + string-based plugin loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12442,6 +12442,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meta-capi-param-builder-clientjs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/meta-capi-param-builder-clientjs/-/meta-capi-param-builder-clientjs-1.3.0.tgz",
+      "integrity": "sha512-Bx/PE8htzljopHRXRZN1gXBp2/bHspA9m2ysTyLWd6Jcr81pZsGgEYQWCI+suhpmjfNd4aQkUt2B/2k+lZ3jvg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/metaviewport-parser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
@@ -16831,6 +16840,7 @@
         "dlv": "^1.1.3",
         "dset": "^3.1.2",
         "js-cookie": "3.0.1",
+        "meta-capi-param-builder-clientjs": "^1.3.0",
         "node-fetch": "^2.6.7",
         "spark-md5": "^3.0.1",
         "tslib": "^2.4.1",
@@ -16946,7 +16956,7 @@
     },
     "packages/node": {
       "name": "@ht-sdks/events-sdk-js-node",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@ht-sdks/events-sdk-js-core": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12442,15 +12442,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/meta-capi-param-builder-clientjs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/meta-capi-param-builder-clientjs/-/meta-capi-param-builder-clientjs-1.3.0.tgz",
-      "integrity": "sha512-Bx/PE8htzljopHRXRZN1gXBp2/bHspA9m2ysTyLWd6Jcr81pZsGgEYQWCI+suhpmjfNd4aQkUt2B/2k+lZ3jvg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/metaviewport-parser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
@@ -16840,7 +16831,7 @@
         "dlv": "^1.1.3",
         "dset": "^3.1.2",
         "js-cookie": "3.0.1",
-        "meta-capi-param-builder-clientjs": "^1.3.0",
+        "meta-capi-param-builder-clientjs": "~1.2.2",
         "node-fetch": "^2.6.7",
         "spark-md5": "^3.0.1",
         "tslib": "^2.4.1",
@@ -16887,6 +16878,15 @@
         "webpack": "^5.76.0",
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^4.8.0"
+      }
+    },
+    "packages/browser/node_modules/meta-capi-param-builder-clientjs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/meta-capi-param-builder-clientjs/-/meta-capi-param-builder-clientjs-1.2.2.tgz",
+      "integrity": "sha512-/iHZNphlJGMJAT/1dodUbkGCFIWh/yU/Kw6LxUrYECWo9iU46zeigPsCvUJW0Ai701um5dvBkxIthgqMAxhZNA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/config": {

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -216,6 +216,62 @@ $ npm run serve -- --port=8080
 
 # Plugins
 
+## Built-in plugins
+
+### Facebook Parameters (`facebook-params`)
+
+The Facebook Parameters plugin uses [Meta's official client-side ParamBuilder SDK](https://developers.facebook.com/docs/marketing-api/conversions-api/parameter-builder-feature-library/client-side-onboarding) to collect `fbc` and `fbp` values and attach them to every event's `context`. These fields improve match quality when forwarding events to Meta's Conversions API.
+
+The plugin is **opt-in** — it is not enabled by default.
+
+**Context fields added:**
+
+| Field | Description |
+| --- | --- |
+| `context.fbc` | Facebook click ID (from `fbclid` in the URL, stored in the `_fbc` cookie) |
+| `context.fbp` | Facebook browser ID (stored in the `_fbp` cookie) |
+
+**Snippet (CDN):**
+
+```javascript
+htevents.load("<WRITE_KEY>", {
+  apiHost: "<DATA_PLANE_URL>",
+  plugins: ["facebook-params"],
+});
+```
+
+**NPM:**
+
+```ts
+import {
+  HtEventsBrowser,
+  facebookParams,
+} from '@ht-sdks/events-sdk-js-browser'
+
+const htevents = HtEventsBrowser.load({
+  writeKey: '<YOUR_WRITE_KEY>',
+  plugins: [facebookParams],
+})
+```
+
+You can also pass the plugin factory if you prefer:
+
+```ts
+import {
+  HtEventsBrowser,
+  createFacebookParamsPlugin,
+} from '@ht-sdks/events-sdk-js-browser'
+
+const htevents = HtEventsBrowser.load({
+  writeKey: '<YOUR_WRITE_KEY>',
+  plugins: [createFacebookParamsPlugin()],
+})
+```
+
+The plugin loads as a critical enrichment plugin, so the SDK waits for ParamBuilder to initialize before sending the first events. If ParamBuilder fails to load, events are still sent without `fbc`/`fbp`.
+
+---
+
 When developing against Events SDK JS you will likely be writing plugins, which can augment functionality and enrich data. Plugins are isolated chunks which you can build, test, version, and deploy independently of the rest of the codebase. Plugins are bounded by Events SDK JS which handles things such as observability, retries, and error management.
 
 Plugins can be of two different priorities:

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -224,6 +224,8 @@ The Facebook Parameters plugin uses [Meta's official client-side ParamBuilder SD
 
 The plugin is **opt-in** — it is not enabled by default.
 
+> **Cookies:** Meta's ParamBuilder writes `_fbc`, `_fbp`, or `_fbi` as first-party cookies when the plugin initializes at SDK `load()` time. If your site requires consent before setting tracking cookies, keep this in mind when enabling the plugin.
+
 **Context fields added:**
 
 | Field | Description |

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -243,28 +243,11 @@ htevents.load("<WRITE_KEY>", {
 **NPM:**
 
 ```ts
-import {
-  HtEventsBrowser,
-  facebookParams,
-} from '@ht-sdks/events-sdk-js-browser'
+import { HtEventsBrowser } from '@ht-sdks/events-sdk-js-browser'
 
 const htevents = HtEventsBrowser.load({
   writeKey: '<YOUR_WRITE_KEY>',
-  plugins: [facebookParams],
-})
-```
-
-You can also pass the plugin factory if you prefer:
-
-```ts
-import {
-  HtEventsBrowser,
-  createFacebookParamsPlugin,
-} from '@ht-sdks/events-sdk-js-browser'
-
-const htevents = HtEventsBrowser.load({
-  writeKey: '<YOUR_WRITE_KEY>',
-  plugins: [createFacebookParamsPlugin()],
+  plugins: ['facebook-params'],
 })
 ```
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "@ht-sdks/events-sdk-js-core": "^1.1.0",
+    "meta-capi-param-builder-clientjs": "^1.3.0",
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@ht-sdks/events-sdk-js-core": "^1.1.0",
-    "meta-capi-param-builder-clientjs": "^1.3.0",
+    "meta-capi-param-builder-clientjs": "~1.2.2",
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",

--- a/packages/browser/src/browser/__tests__/dedupe-plugin-likes.test.ts
+++ b/packages/browser/src/browser/__tests__/dedupe-plugin-likes.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import { Plugin } from '../../core/plugin'
+import { PluginFactory } from '../../plugins/remote-loader'
+import {
+  dedupePluginFactories,
+  dedupePlugins,
+  dedupeStringPluginNames,
+} from '../dedupe-plugin-likes'
+import { BuiltInPluginName } from '../../plugins/built-in-plugins'
+
+const plugin = (name: string): Plugin => ({
+  name,
+  type: 'utility',
+  version: '1.0',
+  load: async () => undefined,
+  isLoaded: () => true,
+})
+
+describe('dedupeStringPluginNames', () => {
+  it('removes duplicate string plugin names', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(
+      dedupeStringPluginNames([
+        'a' as BuiltInPluginName,
+        'a' as BuiltInPluginName,
+        'b' as BuiltInPluginName,
+      ])
+    ).toEqual(['a', 'b'])
+
+    expect(warn).toHaveBeenCalledWith('duplicate plugin ignored: a')
+  })
+})
+
+describe('dedupePluginFactories', () => {
+  it('removes duplicate factories by pluginName', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const first = Object.assign(jest.fn(), { pluginName: 'Braze' })
+    const second = Object.assign(jest.fn(), { pluginName: 'Braze' })
+
+    expect(dedupePluginFactories([first, second] as PluginFactory[])).toEqual([
+      first,
+    ])
+
+    expect(warn).toHaveBeenCalledWith('duplicate plugin factory ignored: Braze')
+  })
+})
+
+describe('dedupePlugins', () => {
+  it('silently skips duplicate references', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const xt = plugin('Test Plugin')
+
+    expect(dedupePlugins([xt, xt])).toEqual([xt])
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('warns and skips different instances with the same name', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const first = plugin('Test Plugin')
+    const second = plugin('Test Plugin')
+
+    expect(dedupePlugins([first, second])).toEqual([first])
+    expect(warn).toHaveBeenCalledWith('duplicate plugin ignored: Test Plugin')
+  })
+})

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -148,7 +148,7 @@ describe('Initialization', () => {
     const ready = jest.fn()
 
     const lazyPlugin1: Plugin = {
-      name: 'Test 2',
+      name: 'Test 1',
       type: 'destination',
       version: '1.0',
 

--- a/packages/browser/src/browser/dedupe-plugin-likes.ts
+++ b/packages/browser/src/browser/dedupe-plugin-likes.ts
@@ -1,0 +1,62 @@
+import { Plugin } from '../core/plugin'
+import { PluginFactory } from '../plugins/remote-loader'
+import type { BuiltInPluginName } from '../plugins/built-in-plugins'
+
+export function dedupeStringPluginNames(
+  names: BuiltInPluginName[]
+): BuiltInPluginName[] {
+  const seen = new Set<BuiltInPluginName>()
+  const unique: BuiltInPluginName[] = []
+
+  for (const name of names) {
+    if (seen.has(name)) {
+      console.warn(`duplicate plugin ignored: ${name}`)
+      continue
+    }
+    seen.add(name)
+    unique.push(name)
+  }
+
+  return unique
+}
+
+export function dedupePluginFactories(
+  factories: PluginFactory[]
+): PluginFactory[] {
+  const seen = new Set<string>()
+  const unique: PluginFactory[] = []
+
+  for (const factory of factories) {
+    if (seen.has(factory.pluginName)) {
+      console.warn(`duplicate plugin factory ignored: ${factory.pluginName}`)
+      continue
+    }
+    seen.add(factory.pluginName)
+    unique.push(factory)
+  }
+
+  return unique
+}
+
+export function dedupePlugins(plugins: Plugin[]): Plugin[] {
+  const seenRefs = new Set<Plugin>()
+  const seenNames = new Set<string>()
+  const unique: Plugin[] = []
+
+  for (const plugin of plugins) {
+    if (seenRefs.has(plugin)) {
+      continue
+    }
+
+    if (seenNames.has(plugin.name)) {
+      console.warn(`duplicate plugin ignored: ${plugin.name}`)
+      continue
+    }
+
+    seenRefs.add(plugin)
+    seenNames.add(plugin.name)
+    unique.push(plugin)
+  }
+
+  return unique
+}

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -280,16 +280,17 @@ async function registerPlugins(
           : [pluginOrPlugins]
         return plugins
       } catch (error) {
-        console.warn(`failed to load plugin factory: ${factory.pluginName}`, error)
+        console.warn(
+          `failed to load plugin factory: ${factory.pluginName}`,
+          error
+        )
         return []
       }
     })
   )
 
   const resolvedFactoryPlugins = loadedFactoryPlugins
-    .flatMap((result) =>
-      result.status === 'fulfilled' ? result.value : []
-    )
+    .flatMap((result) => (result.status === 'fulfilled' ? result.value : []))
     .filter((plugin): plugin is Plugin => plugin !== null)
 
   const toRegister = [

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -267,9 +267,7 @@ async function registerPlugins(
   )
 
   const resolvedStringPlugins = loadedStringPlugins
-    .map((result) =>
-      result.status === 'fulfilled' ? result.value : null
-    )
+    .map((result) => (result.status === 'fulfilled' ? result.value : null))
     .filter((plugin): plugin is Plugin => plugin !== null)
 
   const toRegister = [
@@ -416,10 +414,7 @@ async function loadAnalytics(
   // This allows plugins to be specified in either place:
   // - settings.plugins (when using HtEventsBrowser.load({ writeKey, plugins: [...] }))
   // - options.plugins (when using snippet pattern: htevents.load(writeKey, { plugins: [...] }))
-  const plugins = [
-    ...(settings.plugins ?? []),
-    ...(options.plugins ?? []),
-  ]
+  const plugins = [...(settings.plugins ?? []), ...(options.plugins ?? [])]
 
   const classicIntegrations = settings.classicIntegrations ?? []
 

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -412,7 +412,14 @@ async function loadAnalytics(
 
   attachInspector(analytics)
 
-  const plugins = settings.plugins ?? []
+  // Merge plugins from both settings and options
+  // This allows plugins to be specified in either place:
+  // - settings.plugins (when using HtEventsBrowser.load({ writeKey, plugins: [...] }))
+  // - options.plugins (when using snippet pattern: htevents.load(writeKey, { plugins: [...] }))
+  const plugins = [
+    ...(settings.plugins ?? []),
+    ...(options.plugins ?? []),
+  ]
 
   const classicIntegrations = settings.classicIntegrations ?? []
 

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -270,35 +270,11 @@ async function registerPlugins(
     .map((result) => (result.status === 'fulfilled' ? result.value : null))
     .filter((plugin): plugin is Plugin => plugin !== null)
 
-  // Load factory plugins passed directly to load()
-  const loadedFactoryPlugins = await Promise.allSettled(
-    pluginSources.map(async (factory) => {
-      try {
-        const pluginOrPlugins = await factory({})
-        const plugins = Array.isArray(pluginOrPlugins)
-          ? pluginOrPlugins
-          : [pluginOrPlugins]
-        return plugins
-      } catch (error) {
-        console.warn(
-          `failed to load plugin factory: ${factory.pluginName}`,
-          error
-        )
-        return []
-      }
-    })
-  )
-
-  const resolvedFactoryPlugins = loadedFactoryPlugins
-    .flatMap((result) => (result.status === 'fulfilled' ? result.value : []))
-    .filter((plugin): plugin is Plugin => plugin !== null)
-
   const toRegister = [
     validation,
     envEnrichment,
     ...plugins,
     ...resolvedStringPlugins,
-    ...resolvedFactoryPlugins,
     ...legacyDestinations,
     ...remotePlugins,
   ]

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -270,11 +270,34 @@ async function registerPlugins(
     .map((result) => (result.status === 'fulfilled' ? result.value : null))
     .filter((plugin): plugin is Plugin => plugin !== null)
 
+  // Load factory plugins passed directly to load()
+  const loadedFactoryPlugins = await Promise.allSettled(
+    pluginSources.map(async (factory) => {
+      try {
+        const pluginOrPlugins = await factory({})
+        const plugins = Array.isArray(pluginOrPlugins)
+          ? pluginOrPlugins
+          : [pluginOrPlugins]
+        return plugins
+      } catch (error) {
+        console.warn(`failed to load plugin factory: ${factory.pluginName}`, error)
+        return []
+      }
+    })
+  )
+
+  const resolvedFactoryPlugins = loadedFactoryPlugins
+    .flatMap((result) =>
+      result.status === 'fulfilled' ? result.value : []
+    )
+    .filter((plugin): plugin is Plugin => plugin !== null)
+
   const toRegister = [
     validation,
     envEnrichment,
     ...plugins,
     ...resolvedStringPlugins,
+    ...resolvedFactoryPlugins,
     ...legacyDestinations,
     ...remotePlugins,
   ]

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -189,10 +189,16 @@ async function registerPlugins(
   legacyIntegrationSources: ClassicIntegrationSource[]
 ): Promise<Context> {
   // Filter string-based plugin names
-  const stringPluginNames = pluginLikes?.filter(
-    (pluginLike) =>
-      typeof pluginLike === 'string' && BUILT_IN_PLUGINS.includes(pluginLike)
-  ) as BuiltInPluginName[]
+  const stringPluginNames: BuiltInPluginName[] = []
+  for (const pluginLike of pluginLikes) {
+    if (typeof pluginLike === 'string') {
+      if (BUILT_IN_PLUGINS.includes(pluginLike)) {
+        stringPluginNames.push(pluginLike)
+      } else {
+        console.warn(`failed to load plugin: ${pluginLike}`)
+      }
+    } else continue
+  }
 
   // Filter plugin objects
   const plugins = pluginLikes?.filter(

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -268,7 +268,16 @@ async function registerPlugins(
   )
 
   const resolvedStringPlugins = loadedStringPlugins
-    .map((result) => (result.status === 'fulfilled' ? result.value : null))
+    .map((result, index) => {
+      if (result.status === 'fulfilled') {
+        return result.value
+      }
+      console.error(
+        `failed to load plugin: ${stringPluginNames[index]}`,
+        result.reason
+      )
+      return null
+    })
     .filter((plugin): plugin is Plugin => plugin !== null)
 
   const toRegister = [

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -32,7 +32,10 @@ import { attachInspector } from '../core/inspector'
 import { setGlobalAnalyticsKey } from '../lib/global-analytics-helper'
 import { createDestination } from '../plugins/destinations'
 import { createPlugin } from '../plugins'
-import { BUILT_IN_PLUGINS, type BuiltInPluginName } from '../plugins/built-in-plugins'
+import {
+  BUILT_IN_PLUGINS,
+  type BuiltInPluginName,
+} from '../plugins/built-in-plugins'
 
 export interface LegacyIntegrationConfiguration {
   /* @deprecated - This does not indicate browser types anymore */
@@ -187,7 +190,8 @@ async function registerPlugins(
 ): Promise<Context> {
   // Filter string-based plugin names
   const stringPluginNames = pluginLikes?.filter(
-    (pluginLike) => typeof pluginLike === 'string' && BUILT_IN_PLUGINS.includes(pluginLike )
+    (pluginLike) =>
+      typeof pluginLike === 'string' && BUILT_IN_PLUGINS.includes(pluginLike)
   ) as BuiltInPluginName[]
 
   // Filter plugin objects

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -32,6 +32,7 @@ import { attachInspector } from '../core/inspector'
 import { setGlobalAnalyticsKey } from '../lib/global-analytics-helper'
 import { createDestination } from '../plugins/destinations'
 import { createPlugin } from '../plugins'
+import { BUILT_IN_PLUGINS, type BuiltInPluginName } from '../plugins/built-in-plugins'
 
 export interface LegacyIntegrationConfiguration {
   /* @deprecated - This does not indicate browser types anymore */
@@ -181,13 +182,13 @@ async function registerPlugins(
   analytics: Analytics,
   opts: InitOptions,
   options: InitOptions,
-  pluginLikes: (Plugin | PluginFactory | string)[] = [],
+  pluginLikes: (Plugin | PluginFactory | BuiltInPluginName)[] = [],
   legacyIntegrationSources: ClassicIntegrationSource[]
 ): Promise<Context> {
   // Filter string-based plugin names
   const stringPluginNames = pluginLikes?.filter(
-    (pluginLike) => typeof pluginLike === 'string'
-  ) as string[]
+    (pluginLike) => typeof pluginLike === 'string' && BUILT_IN_PLUGINS.includes(pluginLike )
+  ) as BuiltInPluginName[]
 
   // Filter plugin objects
   const plugins = pluginLikes?.filter(

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -36,6 +36,11 @@ import {
   BUILT_IN_PLUGINS,
   type BuiltInPluginName,
 } from '../plugins/built-in-plugins'
+import {
+  dedupePluginFactories,
+  dedupePlugins,
+  dedupeStringPluginNames,
+} from './dedupe-plugin-likes'
 
 export interface LegacyIntegrationConfiguration {
   /* @deprecated - This does not indicate browser types anymore */
@@ -188,8 +193,10 @@ async function registerPlugins(
   pluginLikes: (Plugin | PluginFactory | BuiltInPluginName)[] = [],
   legacyIntegrationSources: ClassicIntegrationSource[]
 ): Promise<Context> {
-  // Filter string-based plugin names
   const stringPluginNames: BuiltInPluginName[] = []
+  const plugins: Plugin[] = []
+  const pluginSources: PluginFactory[] = []
+
   for (const pluginLike of pluginLikes) {
     if (typeof pluginLike === 'string') {
       if (BUILT_IN_PLUGINS.includes(pluginLike)) {
@@ -197,20 +204,22 @@ async function registerPlugins(
       } else {
         console.warn(`failed to load plugin: ${pluginLike}`)
       }
-    } else continue
-  }
-
-  // Filter plugin objects
-  const plugins = pluginLikes?.filter(
-    (pluginLike) => typeof pluginLike === 'object'
-  ) as Plugin[]
-
-  // Filter plugin factories
-  const pluginSources = pluginLikes?.filter(
-    (pluginLike) =>
+    } else if (typeof pluginLike === 'object' && pluginLike !== null) {
+      plugins.push(pluginLike)
+    } else if (
       typeof pluginLike === 'function' &&
       typeof pluginLike.pluginName === 'string'
-  ) as PluginFactory[]
+    ) {
+      pluginSources.push(pluginLike)
+    } else {
+      console.warn(`failed to load plugin: ${pluginLike}`)
+      continue
+    }
+  }
+
+  const uniqueStringPluginNames = dedupeStringPluginNames(stringPluginNames)
+  const uniquePlugins = dedupePlugins(plugins)
+  const uniquePluginSources = dedupePluginFactories(pluginSources)
 
   const tsubMiddleware = hasTsubMiddleware(legacySettings)
     ? await import(
@@ -261,12 +270,12 @@ async function registerPlugins(
     mergedSettings,
     options.obfuscate,
     tsubMiddleware,
-    pluginSources
+    uniquePluginSources
   ).catch(() => [])
 
   // Load string-based plugins
   const loadedStringPlugins = await Promise.allSettled(
-    stringPluginNames.map(async (name) => {
+    uniqueStringPluginNames.map(async (name) => {
       const plugin = await createPlugin(name)
       if (plugin) {
         return plugin
@@ -283,7 +292,7 @@ async function registerPlugins(
         return result.value
       }
       console.error(
-        `failed to load plugin: ${stringPluginNames[index]}`,
+        `failed to load plugin: ${uniqueStringPluginNames[index]}`,
         result.reason
       )
       return null
@@ -293,7 +302,7 @@ async function registerPlugins(
   const toRegister = [
     validation,
     envEnrichment,
-    ...plugins,
+    ...uniquePlugins,
     ...resolvedStringPlugins,
     ...legacyDestinations,
     ...remotePlugins,

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -83,7 +83,7 @@ function createDefaultQueue(
 export interface AnalyticsSettings {
   writeKey: string
   timeout?: number
-  plugins?: (Plugin | PluginFactory)[]
+  plugins?: (Plugin | PluginFactory | string)[]
   classicIntegrations?: ClassicIntegrationSource[]
 }
 

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -140,6 +140,12 @@ export interface InitOptions {
   destinations?: Record<string, DestinationSettings>
 
   /**
+   * Array of plugins to load. Can be plugin instances, plugin factories, or string names.
+   * String names are resolved via createPlugin() for code-split loading.
+   */
+  plugins?: (Plugin | PluginFactory | string)[]
+
+  /**
    * When setting httpCookieServiceOptions, an HTTPCookieService is automatically created
    */
   httpCookieServiceOptions?: HTTPCookieServiceOptions

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -60,6 +60,7 @@ import type {
   HTTPCookieServiceOptions,
 } from '../http-cookies'
 import type { DestinationSettings } from '../../plugins/destinations'
+import type { BuiltInPluginName } from '../../plugins/built-in-plugins'
 
 const deprecationWarning =
   'This is being deprecated and will be not be available in future releases of Analytics JS'
@@ -83,7 +84,7 @@ function createDefaultQueue(
 export interface AnalyticsSettings {
   writeKey: string
   timeout?: number
-  plugins?: (Plugin | PluginFactory | string)[]
+  plugins?: (Plugin | PluginFactory | BuiltInPluginName)[]
   classicIntegrations?: ClassicIntegrationSource[]
 }
 
@@ -140,10 +141,10 @@ export interface InitOptions {
   destinations?: Record<string, DestinationSettings>
 
   /**
-   * Array of plugins to load. Can be plugin instances, plugin factories, or string names.
-   * String names are resolved via createPlugin() for code-split loading.
+   * Array of plugins to load. Can be plugin instances, plugin factories, or built-in plugin names.
+   * Built-in names are resolved via createPlugin() for code-split loading.
    */
-  plugins?: (Plugin | PluginFactory | string)[]
+  plugins?: (Plugin | PluginFactory | BuiltInPluginName)[]
 
   /**
    * When setting httpCookieServiceOptions, an HTTPCookieService is automatically created

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -915,7 +915,7 @@ describe('Custom cookie params', () => {
     )
     customUser.identify('some_id', { trait: true })
 
-    expect(document.cookie).toMatchInlineSnapshot(`"; htjs_user_id=some_id"`)
+    expect(document.cookie).toMatchInlineSnapshot(`"htjs_user_id=some_id"`)
     expect(customUser.id()).toBe('some_id')
     expect(customUser.traits()).toEqual({ trait: true })
   })

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -915,7 +915,7 @@ describe('Custom cookie params', () => {
     )
     customUser.identify('some_id', { trait: true })
 
-    expect(document.cookie).toMatchInlineSnapshot(`"htjs_user_id=some_id"`)
+    expect(document.cookie).toMatchInlineSnapshot(`"; htjs_user_id=some_id"`)
     expect(customUser.id()).toBe('some_id')
     expect(customUser.traits()).toEqual({ trait: true })
   })

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -10,5 +10,9 @@ export * from './core/user'
 export type { HtEventsSnippet } from './browser/standalone-interface'
 export type { MiddlewareFunction } from './plugins/middleware'
 export { Destination } from './plugins/destinations'
+export {
+  facebookParams,
+  createFacebookParamsPlugin,
+} from './plugins/facebook-params'
 export { getGlobalAnalytics } from './lib/global-analytics-helper'
 export { UniversalStorage, Store, StorageObject } from './core/storage'

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -10,9 +10,6 @@ export * from './core/user'
 export type { HtEventsSnippet } from './browser/standalone-interface'
 export type { MiddlewareFunction } from './plugins/middleware'
 export { Destination } from './plugins/destinations'
-export {
-  facebookParams,
-  createFacebookParamsPlugin,
-} from './plugins/facebook-params'
+export type { BuiltInPluginName } from './plugins/built-in-plugins'
 export { getGlobalAnalytics } from './lib/global-analytics-helper'
 export { UniversalStorage, Store, StorageObject } from './core/storage'

--- a/packages/browser/src/plugins/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/__tests__/index.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { HtEventsBrowser } from '../../browser'
+import { BUILT_IN_PLUGINS, type BuiltInPluginName } from '../built-in-plugins'
+import { facebookParams } from '../facebook-params'
+import { createPlugin } from '../index'
+
+const mockSDK = {
+  processAndCollectAllParams:
+    jest.fn<() => Promise<{ _fbc?: string; _fbp?: string }>>(),
+  getFbc: jest.fn<() => string>(),
+  getFbp: jest.fn<() => string>(),
+  getClientIpAddress: jest.fn<() => string>(),
+}
+
+jest.mock('meta-capi-param-builder-clientjs', () => ({
+  __esModule: true,
+  default: mockSDK,
+}))
+
+describe('createPlugin', () => {
+  it.each(BUILT_IN_PLUGINS)('resolves %s', async (name) => {
+    const plugin = await createPlugin(name)
+
+    expect(plugin).toBeDefined()
+  })
+
+  it('returns the facebook-params singleton', async () => {
+    const plugin = await createPlugin('facebook-params')
+
+    expect(plugin).toBe(facebookParams)
+  })
+
+  it('returns undefined for unknown plugin names', async () => {
+    const plugin = await createPlugin('unknown-plugin' as BuiltInPluginName)
+
+    expect(plugin).toBeUndefined()
+  })
+})
+
+describe('HtEventsBrowser', () => {
+  beforeEach(() => {
+    ;(facebookParams as any).clientParamBuilder = null
+    ;(facebookParams as any).sdkReady = false
+    jest.clearAllMocks()
+  })
+
+  it('loads built-in plugins specified by string name', async () => {
+    mockSDK.processAndCollectAllParams.mockResolvedValue({
+      _fbc: 'fb.1.1234567890.AbCdEf',
+      _fbp: 'fb.1.1234567890.GhIjKl',
+    })
+    mockSDK.getFbc.mockReturnValue('fb.1.1234567890.AbCdEf')
+    mockSDK.getFbp.mockReturnValue('fb.1.1234567890.GhIjKl')
+    mockSDK.getClientIpAddress.mockReturnValue('')
+
+    const analytics = await HtEventsBrowser.standalone('test-write-key', {
+      plugins: ['facebook-params'],
+    })
+
+    const plugin = analytics.queue.plugins.find(
+      (p) => p.name === 'Facebook Parameters'
+    )
+    expect(plugin).toBe(facebookParams)
+    expect(plugin?.isLoaded()).toBe(true)
+  })
+})

--- a/packages/browser/src/plugins/built-in-plugins.ts
+++ b/packages/browser/src/plugins/built-in-plugins.ts
@@ -1,0 +1,3 @@
+export const BUILT_IN_PLUGINS = ['facebook-params'] as const
+
+export type BuiltInPluginName = (typeof BUILT_IN_PLUGINS)[number]

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -1,7 +1,4 @@
-import {
-  facebookParams,
-  createFacebookParamsPlugin,
-} from '../index'
+import { facebookParams, createFacebookParamsPlugin } from '../index'
 import { Context } from '../../../core/context'
 import { Analytics } from '../../../core/analytics'
 import * as loadScriptModule from '../../../lib/load-script'
@@ -55,7 +52,6 @@ describe('FacebookParamsPlugin', () => {
     jest
       .spyOn(loadScriptModule, 'loadScript')
       .mockResolvedValue(document.createElement('script'))
-
     ;(window as any).clientParamBuilder = mockSDK
 
     const ctx = Context.system()
@@ -107,7 +103,6 @@ describe('FacebookParamsPlugin', () => {
     jest
       .spyOn(loadScriptModule, 'loadScript')
       .mockResolvedValue(document.createElement('script'))
-
     ;(window as any).clientParamBuilder = mockSDK
 
     const ctx = Context.system()
@@ -194,10 +189,11 @@ describe('FacebookParamsPlugin', () => {
 
       await plugin.load(ctx, analytics)
 
-      expect(loadScriptSpy).toHaveBeenCalledWith('https://custom.example.com/sdk.js')
+      expect(loadScriptSpy).toHaveBeenCalledWith(
+        'https://custom.example.com/sdk.js'
+      )
 
       jest.restoreAllMocks()
     })
   })
 })
-

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -1,0 +1,123 @@
+import { facebookParams } from '../index'
+import { Context } from '../../../core/context'
+import { Analytics } from '../../../core/analytics'
+import * as loadScriptModule from '../../../lib/load-script'
+
+describe('FacebookParamsPlugin', () => {
+  beforeEach(() => {
+    // Reset plugin state
+    ;(facebookParams as any).fbSDK = null
+    ;(facebookParams as any).sdkReady = false
+    // Clear window globals
+    delete (window as any).FacebookParameterBuilder
+    delete (window as any).ParameterBuilder
+    delete (window as any).fbParameterBuilder
+  })
+
+  it('should have correct plugin metadata', () => {
+    expect(facebookParams.name).toBe('Facebook Parameters')
+    expect(facebookParams.type).toBe('enrichment')
+    expect(facebookParams.version).toBe('0.1.0')
+  })
+
+  it('should not be loaded initially', () => {
+    expect(facebookParams.isLoaded()).toBe(false)
+  })
+
+  it('should not enrich events when SDK is not loaded', () => {
+    const ctx = Context.system()
+    ctx.event = {
+      type: 'track',
+      event: 'test',
+      properties: {},
+      context: {},
+    }
+
+    const enriched = facebookParams.track(ctx)
+    expect(enriched.event.context?.fbc).toBeUndefined()
+    expect(enriched.event.context?.fbp).toBeUndefined()
+  })
+
+  it('should enrich events when SDK is loaded', async () => {
+    // Mock the Facebook SDK
+    const mockSDK = {
+      getFbc: jest.fn(() => 'fb.1.1234567890.AbCdEf'),
+      getFbp: jest.fn(() => 'fb.1.1234567890.GhIjKl'),
+    }
+
+    // Mock loadScript to succeed
+    jest
+      .spyOn(loadScriptModule, 'loadScript')
+      .mockResolvedValue(document.createElement('script'))
+
+    ;(window as any).FacebookParameterBuilder = mockSDK
+
+    const ctx = Context.system()
+    const analytics = new Analytics({ writeKey: 'test' })
+
+    await facebookParams.load(ctx, analytics)
+
+    expect(facebookParams.isLoaded()).toBe(true)
+
+    ctx.event = {
+      type: 'track',
+      event: 'test',
+      properties: {},
+      context: {},
+    }
+
+    const enriched = facebookParams.track(ctx)
+    expect(enriched.event.context?.fbc).toBe('fb.1.1234567890.AbCdEf')
+    expect(enriched.event.context?.fbp).toBe('fb.1.1234567890.GhIjKl')
+
+    jest.restoreAllMocks()
+  })
+
+  it('should handle SDK load errors gracefully', async () => {
+    // Mock loadScript to fail
+    jest
+      .spyOn(loadScriptModule, 'loadScript')
+      .mockRejectedValue(new Error('Failed to load'))
+
+    const ctx = Context.system()
+    const analytics = new Analytics({ writeKey: 'test' })
+
+    // Should not throw
+    await expect(facebookParams.load(ctx, analytics)).resolves.not.toThrow()
+    expect(facebookParams.isLoaded()).toBe(false)
+
+    jest.restoreAllMocks()
+  })
+
+  it('should handle SDK methods that return null', async () => {
+    const mockSDK = {
+      getFbc: jest.fn(() => null),
+      getFbp: jest.fn(() => null),
+    }
+
+    jest
+      .spyOn(loadScriptModule, 'loadScript')
+      .mockResolvedValue(document.createElement('script'))
+
+    ;(window as any).FacebookParameterBuilder = mockSDK
+
+    const ctx = Context.system()
+    const analytics = new Analytics({ writeKey: 'test' })
+
+    await facebookParams.load(ctx, analytics)
+
+    ctx.event = {
+      type: 'track',
+      event: 'test',
+      properties: {},
+      context: {},
+    }
+
+    const enriched = facebookParams.track(ctx)
+    expect(enriched.event.context?.fbc).toBeUndefined()
+    expect(enriched.event.context?.fbp).toBeUndefined()
+
+    jest.restoreAllMocks()
+  })
+})
+

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -15,7 +15,7 @@ jest.mock('meta-capi-param-builder-clientjs', () => ({
   default: mockSDK,
 }))
 
-import { facebookParams, createFacebookParamsPlugin } from '../index'
+import { facebookParams } from '../index'
 
 describe('FacebookParamsPlugin', () => {
   beforeEach(() => {
@@ -113,13 +113,5 @@ describe('FacebookParamsPlugin', () => {
     // Empty strings should not be added to context
     expect(enriched.event.context?.fbc).toBeUndefined()
     expect(enriched.event.context?.fbp).toBeUndefined()
-  })
-
-  describe('createFacebookParamsPlugin factory', () => {
-    it('should create a plugin instance', () => {
-      const plugin = createFacebookParamsPlugin()
-      expect(plugin.name).toBe('Facebook Parameters')
-      expect(plugin.type).toBe('enrichment')
-    })
   })
 })

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -91,6 +91,32 @@ describe('FacebookParamsPlugin', () => {
     expect(facebookParams.isLoaded()).toBe(false)
   })
 
+  it('should handle SDK load timeouts gracefully', async () => {
+    jest.useFakeTimers()
+    mockSDK.processAndCollectAllParams.mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    const ctx = Context.system()
+    const analytics = new Analytics({ writeKey: 'test' })
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const loadPromise = facebookParams.load(ctx, analytics)
+    jest.advanceTimersByTime(2000)
+    await loadPromise
+
+    expect(facebookParams.isLoaded()).toBe(false)
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to load Facebook Parameter Builder SDK:',
+      expect.objectContaining({
+        message: 'Facebook Parameter Builder SDK load timed out',
+      })
+    )
+
+    warnSpy.mockRestore()
+    jest.useRealTimers()
+  })
+
   it('should handle SDK methods that return empty strings', async () => {
     mockSDK.processAndCollectAllParams.mockResolvedValue({})
     mockSDK.getFbc.mockReturnValue('')

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -3,9 +3,8 @@ import { Context } from '../../../core/context'
 import { Analytics } from '../../../core/analytics'
 
 const mockSDK = {
-  processAndCollectAllParams: jest.fn<
-    () => Promise<{ _fbc?: string; _fbp?: string }>
-  >(),
+  processAndCollectAllParams:
+    jest.fn<() => Promise<{ _fbc?: string; _fbp?: string }>>(),
   getFbc: jest.fn<() => string>(),
   getFbp: jest.fn<() => string>(),
   getClientIpAddress: jest.fn<() => string>(),

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -1,15 +1,29 @@
-import { facebookParams, createFacebookParamsPlugin } from '../index'
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { Context } from '../../../core/context'
 import { Analytics } from '../../../core/analytics'
-import * as loadScriptModule from '../../../lib/load-script'
+
+const mockSDK = {
+  processAndCollectAllParams: jest.fn<
+    () => Promise<{ _fbc?: string; _fbp?: string }>
+  >(),
+  getFbc: jest.fn<() => string>(),
+  getFbp: jest.fn<() => string>(),
+  getClientIpAddress: jest.fn<() => string>(),
+}
+
+jest.mock('meta-capi-param-builder-clientjs', () => ({
+  __esModule: true,
+  default: mockSDK,
+}))
+
+import { facebookParams, createFacebookParamsPlugin } from '../index'
 
 describe('FacebookParamsPlugin', () => {
   beforeEach(() => {
     // Reset plugin state
     ;(facebookParams as any).clientParamBuilder = null
     ;(facebookParams as any).sdkReady = false
-    // Clear window globals
-    delete (window as any).clientParamBuilder
+    jest.clearAllMocks()
   })
 
   it('should have correct plugin metadata', () => {
@@ -37,22 +51,13 @@ describe('FacebookParamsPlugin', () => {
   })
 
   it('should enrich events when SDK is loaded', async () => {
-    // Mock the Facebook SDK (clientParamBuilder)
-    const mockSDK = {
-      processAndCollectAllParams: jest.fn().mockResolvedValue({
-        _fbc: 'fb.1.1234567890.AbCdEf',
-        _fbp: 'fb.1.1234567890.GhIjKl',
-      }),
-      getFbc: jest.fn(() => 'fb.1.1234567890.AbCdEf'),
-      getFbp: jest.fn(() => 'fb.1.1234567890.GhIjKl'),
-      getClientIpAddress: jest.fn(() => ''),
-    }
-
-    // Mock loadScript to succeed
-    jest
-      .spyOn(loadScriptModule, 'loadScript')
-      .mockResolvedValue(document.createElement('script'))
-    ;(window as any).clientParamBuilder = mockSDK
+    mockSDK.processAndCollectAllParams.mockResolvedValue({
+      _fbc: 'fb.1.1234567890.AbCdEf',
+      _fbp: 'fb.1.1234567890.GhIjKl',
+    })
+    mockSDK.getFbc.mockReturnValue('fb.1.1234567890.AbCdEf')
+    mockSDK.getFbp.mockReturnValue('fb.1.1234567890.GhIjKl')
+    mockSDK.getClientIpAddress.mockReturnValue('')
 
     const ctx = Context.system()
     const analytics = new Analytics({ writeKey: 'test' })
@@ -72,15 +77,12 @@ describe('FacebookParamsPlugin', () => {
     const enriched = facebookParams.track(ctx)
     expect(enriched.event.context?.fbc).toBe('fb.1.1234567890.AbCdEf')
     expect(enriched.event.context?.fbp).toBe('fb.1.1234567890.GhIjKl')
-
-    jest.restoreAllMocks()
   })
 
   it('should handle SDK load errors gracefully', async () => {
-    // Mock loadScript to fail
-    jest
-      .spyOn(loadScriptModule, 'loadScript')
-      .mockRejectedValue(new Error('Failed to load'))
+    mockSDK.processAndCollectAllParams.mockRejectedValue(
+      new Error('Failed to load')
+    )
 
     const ctx = Context.system()
     const analytics = new Analytics({ writeKey: 'test' })
@@ -88,22 +90,13 @@ describe('FacebookParamsPlugin', () => {
     // Should not throw
     await expect(facebookParams.load(ctx, analytics)).resolves.not.toThrow()
     expect(facebookParams.isLoaded()).toBe(false)
-
-    jest.restoreAllMocks()
   })
 
   it('should handle SDK methods that return empty strings', async () => {
-    const mockSDK = {
-      processAndCollectAllParams: jest.fn().mockResolvedValue({}),
-      getFbc: jest.fn(() => ''),
-      getFbp: jest.fn(() => ''),
-      getClientIpAddress: jest.fn(() => ''),
-    }
-
-    jest
-      .spyOn(loadScriptModule, 'loadScript')
-      .mockResolvedValue(document.createElement('script'))
-    ;(window as any).clientParamBuilder = mockSDK
+    mockSDK.processAndCollectAllParams.mockResolvedValue({})
+    mockSDK.getFbc.mockReturnValue('')
+    mockSDK.getFbp.mockReturnValue('')
+    mockSDK.getClientIpAddress.mockReturnValue('')
 
     const ctx = Context.system()
     const analytics = new Analytics({ writeKey: 'test' })
@@ -121,79 +114,13 @@ describe('FacebookParamsPlugin', () => {
     // Empty strings should not be added to context
     expect(enriched.event.context?.fbc).toBeUndefined()
     expect(enriched.event.context?.fbp).toBeUndefined()
-
-    jest.restoreAllMocks()
   })
 
   describe('createFacebookParamsPlugin factory', () => {
-    it('should create a plugin instance with default SDK URL', () => {
+    it('should create a plugin instance', () => {
       const plugin = createFacebookParamsPlugin()
       expect(plugin.name).toBe('Facebook Parameters')
       expect(plugin.type).toBe('enrichment')
-    })
-
-    it('should create a plugin instance with custom SDK URL', async () => {
-      const customSdkUrl = 'https://custom-cdn.example.com/parameter_builder.js'
-      const plugin = createFacebookParamsPlugin({ sdkUrl: customSdkUrl })
-
-      const loadScriptSpy = jest
-        .spyOn(loadScriptModule, 'loadScript')
-        .mockResolvedValue(document.createElement('script'))
-
-      const mockSDK = {
-        processAndCollectAllParams: jest.fn().mockResolvedValue({
-          _fbc: 'fb.1.1234567890.AbCdEf',
-          _fbp: 'fb.1.1234567890.GhIjKl',
-        }),
-        getFbc: jest.fn(() => 'fb.1.1234567890.AbCdEf'),
-        getFbp: jest.fn(() => 'fb.1.1234567890.GhIjKl'),
-        getClientIpAddress: jest.fn(() => ''),
-      }
-      ;(window as any).clientParamBuilder = mockSDK
-
-      const ctx = Context.system()
-      const analytics = new Analytics({ writeKey: 'test' })
-
-      await plugin.load(ctx, analytics)
-
-      expect(loadScriptSpy).toHaveBeenCalledWith(customSdkUrl)
-      expect(plugin.isLoaded()).toBe(true)
-
-      jest.restoreAllMocks()
-    })
-
-    it('should work as a PluginFactory', async () => {
-      const factory = createFacebookParamsPlugin
-      const plugin = factory({ sdkUrl: 'https://custom.example.com/sdk.js' })
-
-      expect(plugin).toBeDefined()
-      expect(plugin.name).toBe('Facebook Parameters')
-
-      const loadScriptSpy = jest
-        .spyOn(loadScriptModule, 'loadScript')
-        .mockResolvedValue(document.createElement('script'))
-
-      const mockSDK = {
-        processAndCollectAllParams: jest.fn().mockResolvedValue({
-          _fbc: 'fb.1.test',
-          _fbp: 'fb.1.test',
-        }),
-        getFbc: jest.fn(() => 'fb.1.test'),
-        getFbp: jest.fn(() => 'fb.1.test'),
-        getClientIpAddress: jest.fn(() => ''),
-      }
-      ;(window as any).clientParamBuilder = mockSDK
-
-      const ctx = Context.system()
-      const analytics = new Analytics({ writeKey: 'test' })
-
-      await plugin.load(ctx, analytics)
-
-      expect(loadScriptSpy).toHaveBeenCalledWith(
-        'https://custom.example.com/sdk.js'
-      )
-
-      jest.restoreAllMocks()
     })
   })
 })

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -91,6 +91,26 @@ describe('FacebookParamsPlugin', () => {
     expect(facebookParams.isLoaded()).toBe(false)
   })
 
+  it('should clear load timeout when SDK loads successfully', async () => {
+    jest.useFakeTimers()
+    mockSDK.processAndCollectAllParams.mockResolvedValue({})
+    mockSDK.getFbc.mockReturnValue('')
+    mockSDK.getFbp.mockReturnValue('')
+
+    const ctx = Context.system()
+    const analytics = new Analytics({ writeKey: 'test' })
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+
+    await facebookParams.load(ctx, analytics)
+
+    expect(facebookParams.isLoaded()).toBe(true)
+    // withTimeout clears one timer per race (import + processAndCollectAllParams)
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(2)
+
+    clearTimeoutSpy.mockRestore()
+    jest.useRealTimers()
+  })
+
   it('should handle SDK load timeouts gracefully', async () => {
     jest.useFakeTimers()
     mockSDK.processAndCollectAllParams.mockImplementation(

--- a/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/facebook-params/__tests__/index.test.ts
@@ -104,14 +104,13 @@ describe('FacebookParamsPlugin', () => {
     await facebookParams.load(ctx, analytics)
 
     expect(facebookParams.isLoaded()).toBe(true)
-    // withTimeout clears one timer per race (import + processAndCollectAllParams)
-    expect(clearTimeoutSpy).toHaveBeenCalledTimes(2)
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
 
     clearTimeoutSpy.mockRestore()
     jest.useRealTimers()
   })
 
-  it('should handle SDK load timeouts gracefully', async () => {
+  it('should unblock the event queue when SDK load times out', async () => {
     jest.useFakeTimers()
     mockSDK.processAndCollectAllParams.mockImplementation(
       () => new Promise(() => {})
@@ -126,14 +125,56 @@ describe('FacebookParamsPlugin', () => {
     await loadPromise
 
     expect(facebookParams.isLoaded()).toBe(false)
-    expect(warnSpy).toHaveBeenCalledWith(
-      'Failed to load Facebook Parameter Builder SDK:',
-      expect.objectContaining({
-        message: 'Facebook Parameter Builder SDK load timed out',
-      })
-    )
+    expect(warnSpy).not.toHaveBeenCalled()
 
     warnSpy.mockRestore()
+    jest.useRealTimers()
+  })
+
+  it('should enrich later events when SDK finishes loading after the timeout', async () => {
+    jest.useFakeTimers()
+    let resolveProcess!: (value: { _fbc?: string; _fbp?: string }) => void
+    mockSDK.processAndCollectAllParams.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveProcess = resolve
+        })
+    )
+    mockSDK.getFbc.mockReturnValue('fb.1.1234567890.AbCdEf')
+    mockSDK.getFbp.mockReturnValue('fb.1.1234567890.GhIjKl')
+
+    const ctx = Context.system()
+    const analytics = new Analytics({ writeKey: 'test' })
+
+    const loadPromise = facebookParams.load(ctx, analytics)
+    jest.advanceTimersByTime(2000)
+    await loadPromise
+
+    expect(facebookParams.isLoaded()).toBe(false)
+
+    ctx.event = {
+      type: 'track',
+      event: 'early',
+      properties: {},
+      context: {},
+    }
+    expect(facebookParams.track(ctx).event.context?.fbc).toBeUndefined()
+
+    resolveProcess({ _fbc: 'fb.1.1234567890.AbCdEf' })
+    await Promise.resolve()
+
+    expect(facebookParams.isLoaded()).toBe(true)
+
+    ctx.event = {
+      type: 'track',
+      event: 'late',
+      properties: {},
+      context: {},
+    }
+    const enriched = facebookParams.track(ctx)
+    expect(enriched.event.context?.fbc).toBe('fb.1.1234567890.AbCdEf')
+    expect(enriched.event.context?.fbp).toBe('fb.1.1234567890.GhIjKl')
+
     jest.useRealTimers()
   })
 

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -163,4 +163,3 @@ export function createFacebookParamsPlugin(
 ): Plugin {
   return new FacebookParamsPlugin(settings)
 }
-

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -111,8 +111,6 @@ class FacebookParamsPlugin implements Plugin {
 
     try {
       const evtCtx = ctx.event.context
-      // TODO test adding to properties instead?
-      // const evtProps = ctx.event.properties
       if (!evtCtx) {
         return ctx
       }

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -1,0 +1,97 @@
+import type { Context } from '../../core/context'
+import type { Plugin } from '../../core/plugin'
+import { PluginType } from '@ht-sdks/events-sdk-js-core'
+import { Analytics } from '../../core/analytics'
+import { loadScript } from '../../lib/load-script'
+import { isServer } from '../../core/environment'
+
+// Facebook Parameter Builder SDK types
+interface FacebookParameterBuilder {
+  getFbc(): string | null
+  getFbp(): string | null
+}
+
+class FacebookParamsPlugin implements Plugin {
+  private fbSDK: FacebookParameterBuilder | null = null
+  private sdkReady = false
+
+  name = 'Facebook Parameters'
+  type: PluginType = 'enrichment'
+  version = '0.1.0'
+
+  isLoaded = () => this.sdkReady
+
+  load = async (_ctx: Context, _instance: Analytics): Promise<void> => {
+    if (isServer()) {
+      // Server-side rendering - skip loading
+      return Promise.resolve()
+    }
+
+    try {
+      // Load Facebook Parameter Builder SDK from CDN
+      // Using jsdelivr CDN to serve the client_js file from GitHub
+      await loadScript(
+        'https://cdn.jsdelivr.net/gh/facebook/capi-param-builder@main/client_js/parameter_builder.js'
+      )
+
+      // The SDK should be available on window after loading
+      // Check for common global names the SDK might use
+      const fbSDK =
+        (window as any).FacebookParameterBuilder ||
+        (window as any).ParameterBuilder ||
+        (window as any).fbParameterBuilder
+
+      if (fbSDK && typeof fbSDK.getFbc === 'function' && typeof fbSDK.getFbp === 'function') {
+        this.fbSDK = fbSDK as FacebookParameterBuilder
+        this.sdkReady = true
+      } else {
+        // SDK loaded but doesn't have expected interface
+        console.warn(
+          'Facebook Parameter Builder SDK loaded but does not expose expected interface'
+        )
+      }
+    } catch (error) {
+      // Graceful degradation - plugin will simply not enrich events
+      console.warn('Failed to load Facebook Parameter Builder SDK:', error)
+    }
+  }
+
+  private enrich = (ctx: Context): Context => {
+    if (!this.sdkReady || !this.fbSDK) {
+      return ctx
+    }
+
+    try {
+      const evtCtx = ctx.event.context
+      if (!evtCtx) {
+        return ctx
+      }
+
+      const fbc = this.fbSDK.getFbc()
+      const fbp = this.fbSDK.getFbp()
+
+      if (fbc) {
+        evtCtx.fbc = fbc
+      }
+
+      if (fbp) {
+        evtCtx.fbp = fbp
+      }
+    } catch (error) {
+      // Silently fail - don't break event processing if SDK has issues
+      console.warn('Error extracting Facebook parameters:', error)
+    }
+
+    return ctx
+  }
+
+  track = this.enrich
+  identify = this.enrich
+  page = this.enrich
+  group = this.enrich
+  alias = this.enrich
+  screen = this.enrich
+}
+
+export const facebookParams = new FacebookParamsPlugin()
+

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -5,19 +5,58 @@ import { Analytics } from '../../core/analytics'
 import { loadScript } from '../../lib/load-script'
 import { isServer } from '../../core/environment'
 
-// Facebook Parameter Builder SDK types
-interface FacebookParameterBuilder {
-  getFbc(): string | null
-  getFbp(): string | null
+// Facebook Parameter Builder SDK types (clientParamBuilder)
+// Based on Meta's official API: https://developers.facebook.com/docs/marketing-api/conversions-api/parameter-builder-feature-library/client-side-onboarding
+interface ClientParamBuilder {
+  /**
+   * Processes and collects all parameters (fbc, fbp, client_ip_address).
+   * Must be called before getFbc(), getFbp(), or getClientIpAddress().
+   * @param url - Optional. The full URL to collect clickID from. If not provided, uses window.location.href
+   * @param getIpFn - Optional. Function to retrieve client IPv6 address (fallback to IPv4 if unavailable)
+   * @returns Promise that resolves to updated cookie object with _fbc, _fbp, and _fbi keys
+   */
+  processAndCollectAllParams(
+    url?: string,
+    getIpFn?: () => Promise<string>
+  ): Promise<{ _fbc?: string; _fbp?: string; _fbi?: string }>
+  /**
+   * Returns the fbc value from cookie. Returns empty string if cookie does not exist.
+   */
+  getFbc(): string
+  /**
+   * Returns the fbp value from cookie. Returns empty string if cookie does not exist.
+   */
+  getFbp(): string
+  /**
+   * Returns the client_ip_address value from cookie. Returns empty string if cookie does not exist.
+   */
+  getClientIpAddress(): string
 }
 
+export interface FacebookParamsSettings {
+  /**
+   * Custom URL for the Facebook Parameter Builder SDK (clientParamBuilder).
+   * If not provided, defaults to Meta's official S3-hosted bundle.
+   */
+  sdkUrl?: string
+}
+
+// Yes, the official Meta docs say to use this S3 URL.
+const DEFAULT_SDK_URL =
+  'https://capi-automation.s3.us-east-2.amazonaws.com/public/client_js/capiParamBuilder/clientParamBuilder.bundle.js'
+
 class FacebookParamsPlugin implements Plugin {
-  private fbSDK: FacebookParameterBuilder | null = null
+  private clientParamBuilder: ClientParamBuilder | null = null
   private sdkReady = false
+  private sdkUrl: string
 
   name = 'Facebook Parameters'
   type: PluginType = 'enrichment'
   version = '0.1.0'
+
+  constructor(settings?: FacebookParamsSettings) {
+    this.sdkUrl = settings?.sdkUrl ?? DEFAULT_SDK_URL
+  }
 
   isLoaded = () => this.sdkReady
 
@@ -28,26 +67,31 @@ class FacebookParamsPlugin implements Plugin {
     }
 
     try {
-      // Load Facebook Parameter Builder SDK from CDN
-      // Using jsdelivr CDN to serve the client_js file from GitHub
-      await loadScript(
-        'https://cdn.jsdelivr.net/gh/facebook/capi-param-builder@main/client_js/parameter_builder.js'
-      )
+      // Load Facebook Parameter Builder SDK
+      await loadScript(this.sdkUrl)
 
-      // The SDK should be available on window after loading
-      // Check for common global names the SDK might use
-      const fbSDK =
-        (window as any).FacebookParameterBuilder ||
-        (window as any).ParameterBuilder ||
-        (window as any).fbParameterBuilder
+      // The SDK is exposed as clientParamBuilder on window
+      // Reference: https://developers.facebook.com/docs/marketing-api/conversions-api/parameter-builder-feature-library/client-side-onboarding
+      const clientParamBuilder = (window as any).clientParamBuilder
 
-      if (fbSDK && typeof fbSDK.getFbc === 'function' && typeof fbSDK.getFbp === 'function') {
-        this.fbSDK = fbSDK as FacebookParameterBuilder
+      if (
+        clientParamBuilder &&
+        typeof clientParamBuilder.processAndCollectAllParams === 'function' &&
+        typeof clientParamBuilder.getFbc === 'function' &&
+        typeof clientParamBuilder.getFbp === 'function'
+      ) {
+        this.clientParamBuilder = clientParamBuilder as ClientParamBuilder
+
+        // Call processAndCollectAllParams() first as required by Meta's API
+        // This processes the URL, extracts fbclid if present, and saves cookies
+        // We don't provide getIpFn since we're only interested in fbc/fbp, not client_ip_address
+        await this.clientParamBuilder.processAndCollectAllParams()
+
         this.sdkReady = true
       } else {
         // SDK loaded but doesn't have expected interface
         console.warn(
-          'Facebook Parameter Builder SDK loaded but does not expose expected interface'
+          'Facebook Parameter Builder SDK loaded but clientParamBuilder is not available or does not expose expected interface'
         )
       }
     } catch (error) {
@@ -57,19 +101,23 @@ class FacebookParamsPlugin implements Plugin {
   }
 
   private enrich = (ctx: Context): Context => {
-    if (!this.sdkReady || !this.fbSDK) {
+    if (!this.sdkReady || !this.clientParamBuilder) {
       return ctx
     }
 
     try {
       const evtCtx = ctx.event.context
+      // TODO test adding to properties instead?
+      // const evtProps = ctx.event.properties
       if (!evtCtx) {
         return ctx
       }
 
-      const fbc = this.fbSDK.getFbc()
-      const fbp = this.fbSDK.getFbp()
+      // Get fbc and fbp from cookies (processAndCollectAllParams was called during load)
+      const fbc = this.clientParamBuilder.getFbc()
+      const fbp = this.clientParamBuilder.getFbp()
 
+      // Only add if not empty (getFbc/getFbp return empty string if cookie doesn't exist)
       if (fbc) {
         evtCtx.fbc = fbc
       }
@@ -93,5 +141,26 @@ class FacebookParamsPlugin implements Plugin {
   screen = this.enrich
 }
 
+/**
+ * Default plugin instance (uses default SDK URL from Meta's official S3 bucket).
+ * Used when plugin is loaded via string name: plugins: ["facebook-params"]
+ */
 export const facebookParams = new FacebookParamsPlugin()
+
+/**
+ * Factory function to create a FacebookParamsPlugin with custom settings.
+ * Used with PluginFactory pattern to allow custom SDK URLs.
+ *
+ * @example
+ * ```javascript
+ * const factory = (settings) => createFacebookParamsPlugin(settings);
+ * factory.pluginName = 'facebook-params';
+ * htevents.load("KEY", { plugins: [factory] });
+ * ```
+ */
+export function createFacebookParamsPlugin(
+  settings?: FacebookParamsSettings
+): Plugin {
+  return new FacebookParamsPlugin(settings)
+}
 

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -6,12 +6,22 @@ import { isServer } from '../../core/environment'
 import type { ClientParamBuilder } from 'meta-capi-param-builder-clientjs'
 
 const SDK_LOAD_TIMEOUT_MS = 2000
+const SDK_LOAD_TIMEOUT_MESSAGE =
+  'Facebook Parameter Builder SDK load timed out'
 
-function sdkLoadTimeout(): Promise<never> {
-  return new Promise((_, reject) => {
-    setTimeout(() => {
-      reject(new Error('Facebook Parameter Builder SDK load timed out'))
-    }, SDK_LOAD_TIMEOUT_MS)
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>
+
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => {
+    clearTimeout(timer)
   })
 }
 
@@ -35,12 +45,13 @@ class FacebookParamsPlugin implements Plugin {
     // This ensures fbc/fbp are included in events from the start
     await _instance.queue.criticalTasks.run(async () => {
       try {
-        const paramBuilderModule = await Promise.race([
+        const paramBuilderModule = await withTimeout(
           import(
             /* webpackChunkName: "meta-param-builder" */ 'meta-capi-param-builder-clientjs'
           ),
-          sdkLoadTimeout(),
-        ])
+          SDK_LOAD_TIMEOUT_MS,
+          SDK_LOAD_TIMEOUT_MESSAGE
+        )
         const clientParamBuilder = (paramBuilderModule.default ??
           paramBuilderModule) as ClientParamBuilder
 
@@ -50,10 +61,11 @@ class FacebookParamsPlugin implements Plugin {
           typeof clientParamBuilder.getFbc === 'function' &&
           typeof clientParamBuilder.getFbp === 'function'
         ) {
-          await Promise.race([
+          await withTimeout(
             clientParamBuilder.processAndCollectAllParams(),
-            sdkLoadTimeout(),
-          ])
+            SDK_LOAD_TIMEOUT_MS,
+            SDK_LOAD_TIMEOUT_MESSAGE
+          )
 
           this.clientParamBuilder = clientParamBuilder
           this.sdkReady = true

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -6,8 +6,7 @@ import { isServer } from '../../core/environment'
 import type { ClientParamBuilder } from 'meta-capi-param-builder-clientjs'
 
 const SDK_LOAD_TIMEOUT_MS = 2000
-const SDK_LOAD_TIMEOUT_MESSAGE =
-  'Facebook Parameter Builder SDK load timed out'
+const SDK_LOAD_TIMEOUT_MESSAGE = 'Facebook Parameter Builder SDK load timed out'
 
 function withTimeout<T>(
   promise: Promise<T>,
@@ -41,45 +40,39 @@ class FacebookParamsPlugin implements Plugin {
       return Promise.resolve()
     }
 
-    // Mark this plugin as critical so events wait for it to load
-    // This ensures fbc/fbp are included in events from the start
-    await _instance.queue.criticalTasks.run(async () => {
-      try {
-        const paramBuilderModule = await withTimeout(
-          import(
-            /* webpackChunkName: "meta-param-builder" */ 'meta-capi-param-builder-clientjs'
-          ),
-          SDK_LOAD_TIMEOUT_MS,
-          SDK_LOAD_TIMEOUT_MESSAGE
+    // Runs to completion on its own, even if the race below gives up waiting
+    const init = (async () => {
+      const paramBuilderModule = await import(
+        /* webpackChunkName: "meta-param-builder" */ 'meta-capi-param-builder-clientjs'
+      )
+      const clientParamBuilder = (paramBuilderModule.default ??
+        paramBuilderModule) as ClientParamBuilder
+
+      if (
+        !clientParamBuilder ||
+        typeof clientParamBuilder.processAndCollectAllParams !== 'function' ||
+        typeof clientParamBuilder.getFbc !== 'function' ||
+        typeof clientParamBuilder.getFbp !== 'function'
+      ) {
+        console.warn(
+          'Facebook Parameter Builder SDK loaded but clientParamBuilder is not available or does not expose expected interface'
         )
-        const clientParamBuilder = (paramBuilderModule.default ??
-          paramBuilderModule) as ClientParamBuilder
-
-        if (
-          clientParamBuilder &&
-          typeof clientParamBuilder.processAndCollectAllParams === 'function' &&
-          typeof clientParamBuilder.getFbc === 'function' &&
-          typeof clientParamBuilder.getFbp === 'function'
-        ) {
-          await withTimeout(
-            clientParamBuilder.processAndCollectAllParams(),
-            SDK_LOAD_TIMEOUT_MS,
-            SDK_LOAD_TIMEOUT_MESSAGE
-          )
-
-          this.clientParamBuilder = clientParamBuilder
-          this.sdkReady = true
-        } else {
-          // SDK loaded but doesn't have expected interface
-          console.warn(
-            'Facebook Parameter Builder SDK loaded but clientParamBuilder is not available or does not expose expected interface'
-          )
-        }
-      } catch (error) {
-        // Graceful degradation - plugin will simply not enrich events
-        console.warn('Failed to load Facebook Parameter Builder SDK:', error)
+        return
       }
+
+      await clientParamBuilder.processAndCollectAllParams()
+      this.clientParamBuilder = clientParamBuilder
+      this.sdkReady = true
+    })().catch((error) => {
+      console.warn('Failed to load Facebook Parameter Builder SDK:', error)
     })
+
+    // Timeout only bounds how long the event queue waits — it doesn't cancel init
+    await _instance.queue.criticalTasks.run(() =>
+      withTimeout(init, SDK_LOAD_TIMEOUT_MS, SDK_LOAD_TIMEOUT_MESSAGE).catch(
+        () => {}
+      )
+    )
   }
 
   private enrich = (ctx: Context): Context => {

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -2,61 +2,16 @@ import type { Context } from '../../core/context'
 import type { Plugin } from '../../core/plugin'
 import { PluginType } from '@ht-sdks/events-sdk-js-core'
 import { Analytics } from '../../core/analytics'
-import { loadScript } from '../../lib/load-script'
 import { isServer } from '../../core/environment'
-
-// Facebook Parameter Builder SDK types (clientParamBuilder)
-// Based on Meta's official API: https://developers.facebook.com/docs/marketing-api/conversions-api/parameter-builder-feature-library/client-side-onboarding
-interface ClientParamBuilder {
-  /**
-   * Processes and collects all parameters (fbc, fbp, client_ip_address).
-   * Must be called before getFbc(), getFbp(), or getClientIpAddress().
-   * @param url - Optional. The full URL to collect clickID from. If not provided, uses window.location.href
-   * @param getIpFn - Optional. Function to retrieve client IPv6 address (fallback to IPv4 if unavailable)
-   * @returns Promise that resolves to updated cookie object with _fbc, _fbp, and _fbi keys
-   */
-  processAndCollectAllParams(
-    url?: string,
-    getIpFn?: () => Promise<string>
-  ): Promise<{ _fbc?: string; _fbp?: string; _fbi?: string }>
-  /**
-   * Returns the fbc value from cookie. Returns empty string if cookie does not exist.
-   */
-  getFbc(): string
-  /**
-   * Returns the fbp value from cookie. Returns empty string if cookie does not exist.
-   */
-  getFbp(): string
-  /**
-   * Returns the client_ip_address value from cookie. Returns empty string if cookie does not exist.
-   */
-  getClientIpAddress(): string
-}
-
-export interface FacebookParamsSettings {
-  /**
-   * Custom URL for the Facebook Parameter Builder SDK (clientParamBuilder).
-   * If not provided, defaults to Meta's official S3-hosted bundle.
-   */
-  sdkUrl?: string
-}
-
-// Yes, the official Meta docs say to use this S3 URL.
-const DEFAULT_SDK_URL =
-  'https://capi-automation.s3.us-east-2.amazonaws.com/public/client_js/capiParamBuilder/clientParamBuilder.bundle.js'
+import type { ClientParamBuilder } from 'meta-capi-param-builder-clientjs'
 
 class FacebookParamsPlugin implements Plugin {
   private clientParamBuilder: ClientParamBuilder | null = null
   private sdkReady = false
-  private sdkUrl: string
 
   name = 'Facebook Parameters'
   type: PluginType = 'enrichment'
   version = '0.1.0'
-
-  constructor(settings?: FacebookParamsSettings) {
-    this.sdkUrl = settings?.sdkUrl ?? DEFAULT_SDK_URL
-  }
 
   isLoaded = () => this.sdkReady
 
@@ -70,12 +25,11 @@ class FacebookParamsPlugin implements Plugin {
     // This ensures fbc/fbp are included in events from the start
     await _instance.queue.criticalTasks.run(async () => {
       try {
-        // Load Facebook Parameter Builder SDK
-        await loadScript(this.sdkUrl)
-
-        // The SDK is exposed as clientParamBuilder on window
-        // Reference: https://developers.facebook.com/docs/marketing-api/conversions-api/parameter-builder-feature-library/client-side-onboarding
-        const clientParamBuilder = (window as any).clientParamBuilder
+        const paramBuilderModule = await import(
+          /* webpackChunkName: "meta-param-builder" */ 'meta-capi-param-builder-clientjs'
+        )
+        const clientParamBuilder = (paramBuilderModule.default ??
+          paramBuilderModule) as ClientParamBuilder
 
         if (
           clientParamBuilder &&
@@ -83,7 +37,7 @@ class FacebookParamsPlugin implements Plugin {
           typeof clientParamBuilder.getFbc === 'function' &&
           typeof clientParamBuilder.getFbp === 'function'
         ) {
-          this.clientParamBuilder = clientParamBuilder as ClientParamBuilder
+          this.clientParamBuilder = clientParamBuilder
 
           // Call processAndCollectAllParams() first as required by Meta's API
           // This processes the URL, extracts fbclid if present, and saves cookies
@@ -144,24 +98,19 @@ class FacebookParamsPlugin implements Plugin {
 }
 
 /**
- * Default plugin instance (uses default SDK URL from Meta's official S3 bucket).
+ * Default plugin instance using Meta's official ParamBuilder SDK.
  * Used when plugin is loaded via string name: plugins: ["facebook-params"]
  */
 export const facebookParams = new FacebookParamsPlugin()
 
 /**
- * Factory function to create a FacebookParamsPlugin with custom settings.
- * Used with PluginFactory pattern to allow custom SDK URLs.
+ * Factory function to create a FacebookParamsPlugin instance.
  *
  * @example
  * ```javascript
- * const factory = (settings) => createFacebookParamsPlugin(settings);
- * factory.pluginName = 'facebook-params';
- * htevents.load("KEY", { plugins: [factory] });
+ * htevents.load("KEY", { plugins: [createFacebookParamsPlugin()] });
  * ```
  */
-export function createFacebookParamsPlugin(
-  settings?: FacebookParamsSettings
-): Plugin {
-  return new FacebookParamsPlugin(settings)
+export function createFacebookParamsPlugin(): Plugin {
+  return new FacebookParamsPlugin()
 }

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -5,6 +5,16 @@ import { Analytics } from '../../core/analytics'
 import { isServer } from '../../core/environment'
 import type { ClientParamBuilder } from 'meta-capi-param-builder-clientjs'
 
+const SDK_LOAD_TIMEOUT_MS = 2000
+
+function sdkLoadTimeout(): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error('Facebook Parameter Builder SDK load timed out'))
+    }, SDK_LOAD_TIMEOUT_MS)
+  })
+}
+
 class FacebookParamsPlugin implements Plugin {
   private clientParamBuilder: ClientParamBuilder | null = null
   private sdkReady = false
@@ -25,9 +35,12 @@ class FacebookParamsPlugin implements Plugin {
     // This ensures fbc/fbp are included in events from the start
     await _instance.queue.criticalTasks.run(async () => {
       try {
-        const paramBuilderModule = await import(
-          /* webpackChunkName: "meta-param-builder" */ 'meta-capi-param-builder-clientjs'
-        )
+        const paramBuilderModule = await Promise.race([
+          import(
+            /* webpackChunkName: "meta-param-builder" */ 'meta-capi-param-builder-clientjs'
+          ),
+          sdkLoadTimeout(),
+        ])
         const clientParamBuilder = (paramBuilderModule.default ??
           paramBuilderModule) as ClientParamBuilder
 
@@ -37,13 +50,12 @@ class FacebookParamsPlugin implements Plugin {
           typeof clientParamBuilder.getFbc === 'function' &&
           typeof clientParamBuilder.getFbp === 'function'
         ) {
+          await Promise.race([
+            clientParamBuilder.processAndCollectAllParams(),
+            sdkLoadTimeout(),
+          ])
+
           this.clientParamBuilder = clientParamBuilder
-
-          // Call processAndCollectAllParams() first as required by Meta's API
-          // This processes the URL, extracts fbclid if present, and saves cookies
-          // We don't provide getIpFn since we're only interested in fbc/fbp, not client_ip_address
-          await this.clientParamBuilder.processAndCollectAllParams()
-
           this.sdkReady = true
         } else {
           // SDK loaded but doesn't have expected interface

--- a/packages/browser/src/plugins/facebook-params/index.ts
+++ b/packages/browser/src/plugins/facebook-params/index.ts
@@ -102,15 +102,3 @@ class FacebookParamsPlugin implements Plugin {
  * Used when plugin is loaded via string name: plugins: ["facebook-params"]
  */
 export const facebookParams = new FacebookParamsPlugin()
-
-/**
- * Factory function to create a FacebookParamsPlugin instance.
- *
- * @example
- * ```javascript
- * htevents.load("KEY", { plugins: [createFacebookParamsPlugin()] });
- * ```
- */
-export function createFacebookParamsPlugin(): Plugin {
-  return new FacebookParamsPlugin()
-}

--- a/packages/browser/src/plugins/index.ts
+++ b/packages/browser/src/plugins/index.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from '../core/plugin'
+
+/**
+ * Creates a plugin instance from a string name.
+ * This allows script tag users to specify plugins by name without importing them.
+ *
+ * @param name - The name of the plugin to load
+ * @returns A promise that resolves to the plugin instance, or undefined if not found
+ */
+export async function createPlugin(
+  name: string
+): Promise<Plugin | undefined> {
+  switch (name) {
+    case 'facebook-params':
+      return import(
+        /* webpackChunkName: "facebook-params" */ './facebook-params'
+      ).then((mod) => mod.facebookParams)
+    default:
+      return undefined
+  }
+}
+

--- a/packages/browser/src/plugins/index.ts
+++ b/packages/browser/src/plugins/index.ts
@@ -7,9 +7,7 @@ import type { Plugin } from '../core/plugin'
  * @param name - The name of the plugin to load
  * @returns A promise that resolves to the plugin instance, or undefined if not found
  */
-export async function createPlugin(
-  name: string
-): Promise<Plugin | undefined> {
+export async function createPlugin(name: string): Promise<Plugin | undefined> {
   switch (name) {
     case 'facebook-params':
       return import(
@@ -19,4 +17,3 @@ export async function createPlugin(
       return undefined
   }
 }
-

--- a/packages/browser/src/plugins/index.ts
+++ b/packages/browser/src/plugins/index.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from '../core/plugin'
+import type { BuiltInPluginName } from './built-in-plugins'
 
 /**
  * Creates a plugin instance from a string name.
@@ -7,7 +8,9 @@ import type { Plugin } from '../core/plugin'
  * @param name - The name of the plugin to load
  * @returns A promise that resolves to the plugin instance, or undefined if not found
  */
-export async function createPlugin(name: string): Promise<Plugin | undefined> {
+export async function createPlugin(
+  name: BuiltInPluginName
+): Promise<Plugin | undefined> {
   switch (name) {
     case 'facebook-params':
       return import(

--- a/packages/browser/src/types/meta-capi-param-builder-clientjs.d.ts
+++ b/packages/browser/src/types/meta-capi-param-builder-clientjs.d.ts
@@ -1,0 +1,32 @@
+declare module 'meta-capi-param-builder-clientjs' {
+  // Facebook Parameter Builder SDK types (clientParamBuilder)
+  // Based on Meta's official API: https://developers.facebook.com/docs/marketing-api/conversions-api/parameter-builder-feature-library/client-side-onboarding
+  export interface ClientParamBuilder {
+    /**
+     * Processes and collects all parameters (fbc, fbp, client_ip_address).
+     * Must be called before getFbc(), getFbp(), or getClientIpAddress().
+     * @param url - Optional. The full URL to collect clickID from. If not provided, uses window.location.href
+     * @param getIpFn - Optional. Function to retrieve client IPv6 address (fallback to IPv4 if unavailable)
+     * @returns Promise that resolves to updated cookie object with _fbc, _fbp, and _fbi keys
+     */
+    processAndCollectAllParams(
+      url?: string,
+      getIpFn?: () => Promise<string>
+    ): Promise<{ _fbc?: string; _fbp?: string; _fbi?: string }>
+    /**
+     * Returns the fbc value from cookie. Returns empty string if cookie does not exist.
+     */
+    getFbc(): string
+    /**
+     * Returns the fbp value from cookie. Returns empty string if cookie does not exist.
+     */
+    getFbp(): string
+    /**
+     * Returns the client_ip_address value from cookie. Returns empty string if cookie does not exist.
+     */
+    getClientIpAddress(): string
+  }
+
+  const clientParamBuilder: ClientParamBuilder
+  export default clientParamBuilder
+}


### PR DESCRIPTION
## Summary
Adds a built-in Facebook Parameters plugin that enriches events with Meta's `fbc` and `fbp` tracking parameters using [Meta's official client-side ParamBuilder SDK](https://developers.facebook.com/docs/marketing-api/conversions-api/parameter-builder-feature-library/client-side-onboarding). This improves match quality when events are forwarded to Meta's Conversions API.

Also introduces string-based plugin loading, so built-in plugins can be enabled by name (e.g. plugins: ['facebook-params']) — without importing plugin code directly. The plugin is opt-in and degrades gracefully if ParamBuilder fails to load.

## Changes

- Facebook Parameters plugin (`facebook-params`)
  - New enrichment plugin that dynamically imports `meta-capi-param-builder-clientjs` (~1.2.2)
  - Runs as a critical task so the SDK waits for ParamBuilder to initialize before sending the first events
  - Adds `context.fbc` and `context.fbp` to all event types when values are present
  - Includes a 2-second timeout on SDK import and initialization to avoid blocking the event queue on slow networks
  - Gracefully degrades on load failure — events are still sent without fbc/fbp
- String-based plugin loading
  - New `createPlugin(name)` resolver for built-in plugins with code-split dynamic imports
  - `BuiltInPluginName` type (just `'facebook-params'` for now) for type-safety
  - `AnalyticsSettings.plugins` and `InitOptions.plugins` now accept `Plugin | PluginFactory | BuiltInPluginName`

## Testing
1. In `packages/browser/src/tester/dev-server.js`, add the Facebook Parameters plugin:
```
e.load("${WRITE_KEY}", {
  apiHost: "${API_HOST}",
  plugins: ["facebook-params"]
}),
```
2. Run the dev server:
```
cd packages/browser
npm run build:dev && npm run serve -- --writeKey=<WRITE_KEY>
```
3. Open `http://localhost:9900/`. `_fbc` cookie should be set automatically. 
4. Open `http://localhost:9900/?fbclid=test123`. `_fbp` cookie should be set.
5. Trigger a track event. In DevTools → Network, confirm the payload includes `context.fbc` and `context.fbp`.
6. Go to your source's Debugger page in Hightouch. Verify that `context.fbc` and `context.fbp` show up in the captured events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Facebook Parameters built-in plugin that enriches events with `context.fbc` and `context.fbp`.
  * Plugins can now be referenced by built-in name strings (in addition to instances and factories).
  * Plugin loading can be configured at initialization via a new `plugins` option.

* **Documentation**
  * Added a “Built-in plugins” guide covering the Facebook Parameters plugin, including CDN and NPM setup examples.

* **Bug Fixes**
  * Improved plugin load behavior to safely handle SDK load timeouts and failures without breaking event tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->