### PR TITLE
chore: upgrade TypeScript to 5.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.8.0",
         "turbo": "^1.13.0",
-        "typescript": "^4.7.0",
+        "typescript": "^5.9.3",
         "webpack": "^5.76.0",
         "webpack-dev-server": "^5.2.3"
       },
@@ -14186,7 +14186,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14194,7 +14196,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ts-jest": "^29.1.2",
     "ts-node": "^10.8.0",
     "turbo": "^1.13.0",
-    "typescript": "^4.7.0",
+    "typescript": "^5.9.3",
     "webpack": "^5.76.0",
     "webpack-dev-server": "^5.2.3"
   }

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -31,7 +31,7 @@ describe('Pre-initialization', () => {
   const identifySpy = jest.spyOn(Analytics.prototype, 'identify')
   const onSpy = jest.spyOn(Analytics.prototype, 'on')
   const getOnSpyCalls = (event: string) =>
-    onSpy.mock.calls.filter(([arg1]) => arg1 === event)
+    onSpy.mock.calls.filter(([arg1]: [string]) => arg1 === event)
 
   const readySpy = jest.spyOn(Analytics.prototype, 'ready')
   const browserLoadSpy = jest.spyOn(HtEventsBrowser, 'load')

--- a/packages/browser/src/browser/__tests__/query-string.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/query-string.integration.test.ts
@@ -42,11 +42,11 @@ describe('queryString', () => {
     const originalQueryString = Analytics.prototype.queryString
     const mockQueryString = jest.fn().mockImplementation(async function (
       this: Analytics,
-      ...args
+      query: string
     ) {
       // simulate network latency when retrieving the bundle
       await new Promise((r) => setTimeout(r, 500))
-      return originalQueryString.apply(this, args).then((result) => {
+      return originalQueryString.call(this, query).then((result) => {
         // ensure analytics has not finished initializing before querystring completes
         analyticsInitializedBeforeQs = this.initialized
         return result

--- a/packages/browser/src/core/storage/cookieStorage.ts
+++ b/packages/browser/src/core/storage/cookieStorage.ts
@@ -46,7 +46,7 @@ export class CookieStorage<
     }
   }
 
-  get<K extends keyof Data>(key: K): Data[K] | null {
+  get<K extends keyof Data & string>(key: K): Data[K] | null {
     try {
       const value = jar.get(key)
 
@@ -64,7 +64,7 @@ export class CookieStorage<
     }
   }
 
-  set<K extends keyof Data>(key: K, value: Data[K] | null): void {
+  set<K extends keyof Data & string>(key: K, value: Data[K] | null): void {
     if (typeof value === 'string') {
       jar.set(key, value, this.opts())
     } else if (value === null) {
@@ -74,7 +74,7 @@ export class CookieStorage<
     }
   }
 
-  remove<K extends keyof Data>(key: K): void {
+  remove<K extends keyof Data & string>(key: K): void {
     return jar.remove(key, this.opts())
   }
 }

--- a/packages/browser/src/core/storage/localStorage.ts
+++ b/packages/browser/src/core/storage/localStorage.ts
@@ -6,11 +6,14 @@ import { StorageObject, Store } from './types'
 export class LocalStorage<
   Data extends StorageObject = StorageObject,
 > implements Store<Data> {
-  private localStorageWarning(key: keyof Data, state: 'full' | 'unavailable') {
+  private localStorageWarning(
+    key: keyof Data & string,
+    state: 'full' | 'unavailable'
+  ) {
     console.warn(`Unable to access ${key}, localStorage may be ${state}`)
   }
 
-  get<K extends keyof Data>(key: K): Data[K] | null {
+  get<K extends keyof Data & string>(key: K): Data[K] | null {
     try {
       const val = localStorage.getItem(key)
       if (val === null) {
@@ -27,7 +30,7 @@ export class LocalStorage<
     }
   }
 
-  set<K extends keyof Data>(key: K, value: Data[K] | null): void {
+  set<K extends keyof Data & string>(key: K, value: Data[K] | null): void {
     try {
       localStorage.setItem(key, JSON.stringify(value))
     } catch {
@@ -35,7 +38,7 @@ export class LocalStorage<
     }
   }
 
-  remove<K extends keyof Data>(key: K): void {
+  remove<K extends keyof Data & string>(key: K): void {
     try {
       return localStorage.removeItem(key)
     } catch (err) {

--- a/packages/browser/src/core/storage/memoryStorage.ts
+++ b/packages/browser/src/core/storage/memoryStorage.ts
@@ -8,15 +8,15 @@ export class MemoryStorage<
 > implements Store<Data> {
   private cache: Record<string, unknown> = {}
 
-  get<K extends keyof Data>(key: K): Data[K] | null {
+  get<K extends keyof Data & string>(key: K): Data[K] | null {
     return (this.cache[key] ?? null) as Data[K] | null
   }
 
-  set<K extends keyof Data>(key: K, value: Data[K] | null): void {
+  set<K extends keyof Data & string>(key: K, value: Data[K] | null): void {
     this.cache[key] = value
   }
 
-  remove<K extends keyof Data>(key: K): void {
+  remove<K extends keyof Data & string>(key: K): void {
     delete this.cache[key]
   }
 }

--- a/packages/browser/src/core/storage/types.ts
+++ b/packages/browser/src/core/storage/types.ts
@@ -24,7 +24,7 @@ export interface Store<Data extends StorageObject = StorageObject> {
    * @param key key for the value to be retrieved
    * @returns value for the key or null if not found
    */
-  get<K extends keyof Data>(key: K): Data[K] | null
+  get<K extends keyof Data & string>(key: K): Data[K] | null
 
   /**
    * it will set the value for the key in all the stores
@@ -32,13 +32,13 @@ export interface Store<Data extends StorageObject = StorageObject> {
    * @param value value to be stored
    * @returns value that was stored
    */
-  set<K extends keyof Data>(key: K, value: Data[K] | null): void
+  set<K extends keyof Data & string>(key: K, value: Data[K] | null): void
   /**
    * remove the value for the key from all the stores
    * @param key key for the value to be removed
    * @param storeTypes optional array of store types to be used for removing the value
    */
-  remove<K extends keyof Data>(key: K): void
+  remove<K extends keyof Data & string>(key: K): void
 }
 
 export interface StoreTypeWithSettings<T extends StoreType = StoreType> {

--- a/packages/browser/src/core/storage/universalStorage.ts
+++ b/packages/browser/src/core/storage/universalStorage.ts
@@ -22,7 +22,7 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     this.stores = stores
   }
 
-  get<K extends keyof Data>(key: K): Data[K] | null {
+  get<K extends keyof Data & string>(key: K): Data[K] | null {
     let val: Data[K] | null = null
 
     for (const store of this.stores) {
@@ -38,7 +38,7 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     return null
   }
 
-  set<K extends keyof Data>(key: K, value: Data[K] | null): void {
+  set<K extends keyof Data & string>(key: K, value: Data[K] | null): void {
     this.stores.forEach((store) => {
       try {
         store.set(key, value)
@@ -48,7 +48,7 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     })
   }
 
-  clear<K extends keyof Data>(key: K): void {
+  clear<K extends keyof Data & string>(key: K): void {
     this.stores.forEach((store) => {
       try {
         store.remove(key)
@@ -63,7 +63,7 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     - value exist in one of the stores ( as a result of other stores being cleared from browser ) and we want to resync them
     - read values in AJS 1.0 format ( for customers after 1.0 --> 2.0 migration ) and then re-write them in AJS 2.0 format
   */
-  getAndSync<K extends keyof Data>(key: K): Data[K] | null {
+  getAndSync<K extends keyof Data & string>(key: K): Data[K] | null {
     const val = this.get(key)
 
     // legacy behavior, getAndSync can change the type of a value from number to string (AJS 1.0 stores numerical values as a number)

--- a/packages/browser/src/lib/priority-queue/__tests__/persisted.test.ts
+++ b/packages/browser/src/lib/priority-queue/__tests__/persisted.test.ts
@@ -42,11 +42,13 @@ describe('Persisted Priority Queue', () => {
 
     jest
       .spyOn(window, 'addEventListener')
-      .mockImplementation((evt, handler) => {
-        if (evt === 'pagehide') {
-          onUnload = handler
+      .mockImplementation(
+        (evt: string, handler: EventListenerOrEventListenerObject | null) => {
+          if (evt === 'pagehide') {
+            onUnload = handler
+          }
         }
-      })
+      )
 
     const ctx = new Context(
       {
@@ -103,11 +105,13 @@ describe('Persisted Priority Queue', () => {
 
       jest
         .spyOn(window, 'addEventListener')
-        .mockImplementation((evt, handler) => {
-          if (evt === 'pagehide') {
-            onUnload = handler
+        .mockImplementation(
+          (evt: string, handler: EventListenerOrEventListenerObject | null) => {
+            if (evt === 'pagehide') {
+              onUnload = handler
+            }
           }
-        })
+        )
 
       const ctx = new Context(
         {
@@ -201,11 +205,13 @@ describe('Persisted Priority Queue', () => {
 
       jest
         .spyOn(window, 'addEventListener')
-        .mockImplementation((evt, handler) => {
-          if (evt === 'pagehide') {
-            onUnloadFunctions.push(handler)
+        .mockImplementation(
+          (evt: string, handler: EventListenerOrEventListenerObject | null) => {
+            if (evt === 'pagehide') {
+              onUnloadFunctions.push(handler)
+            }
           }
-        })
+        )
 
       const firstTabQueue = new PersistedPriorityQueue(3, key)
       const secondTabQueue = new PersistedPriorityQueue(3, key)

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -6,8 +6,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "lib": ["es2020", "DOM", "DOM.Iterable"],
-    "baseUrl": "./src",
-    "keyofStringsOnly": true
+    "baseUrl": "./src"
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- Remove deprecated keyofStringsOnly option from browser tsconfig
- Fix storage layer types to use 'keyof Data & string'
- Add type annotations to test files for stricter TS5 checks