### PR TITLE
Page path derivation

### DIFF
--- a/packages/browser/src/core/page/__tests__/index.test.ts
+++ b/packages/browser/src/core/page/__tests__/index.test.ts
@@ -3,8 +3,10 @@ import {
   getDefaultBufferedPageContext,
   getDefaultPageContext,
   isBufferedPageContext,
+  addPageContext,
 } from '../'
 import { pickBy } from 'lodash'
+import { HightouchEvent } from '../../events'
 
 const originalLocation = window.location
 beforeEach(() => {
@@ -125,6 +127,142 @@ describe(getDefaultPageContext, () => {
       document.body.appendChild(el)
       const defs = getDefaultPageContext()
       expect(defs.url).toEqual('http://www.hightouch.local?foo=123')
+    })
+  })
+})
+
+describe(addPageContext, () => {
+  const mockPageCtx = {
+    path: '/default-path',
+    referrer: 'https://example.com/referrer',
+    search: '',
+    title: 'Test Page',
+    url: 'https://example.com/default-path',
+  }
+
+  describe('path derivation from user-provided url', () => {
+    it('derives path from url when user provides url but not path', () => {
+      const event: HightouchEvent = {
+        type: 'page',
+        properties: {
+          url: 'https://example.com/new-path',
+          referrer: 'https://example.com/previous-path',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      expect(event.properties?.path).toBe('/new-path')
+      expect(event.context?.page?.path).toBe('/new-path')
+    })
+
+    it('preserves user-provided path when both url and path are provided', () => {
+      const event: HightouchEvent = {
+        type: 'page',
+        properties: {
+          url: 'https://example.com/url-path',
+          path: '/explicit-path',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      expect(event.properties?.path).toBe('/explicit-path')
+      expect(event.context?.page?.path).toBe('/explicit-path')
+    })
+
+    it('uses default path when user does not provide url', () => {
+      const event: HightouchEvent = {
+        type: 'page',
+        properties: {
+          referrer: 'https://example.com/previous-path',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      expect(event.properties?.path).toBe('/default-path')
+      expect(event.context?.page?.path).toBe('/default-path')
+    })
+
+    it('handles complex paths with query strings', () => {
+      const event: HightouchEvent = {
+        type: 'page',
+        properties: {
+          url: 'https://example.com/products/shoes?color=red&size=10',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      expect(event.properties?.path).toBe('/products/shoes')
+      expect(event.context?.page?.path).toBe('/products/shoes')
+    })
+
+    it('handles urls with hash fragments', () => {
+      const event: HightouchEvent = {
+        type: 'page',
+        properties: {
+          url: 'https://example.com/page#section',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      expect(event.properties?.path).toBe('/page')
+      expect(event.context?.page?.path).toBe('/page')
+    })
+
+    it('does not modify path for non-page events', () => {
+      const event: HightouchEvent = {
+        type: 'track',
+        event: 'Test Event',
+        properties: {
+          url: 'https://example.com/some-path',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      // For track events, context.page should use defaults, not derive from properties
+      expect(event.context?.page?.path).toBe('/default-path')
+    })
+
+    it('handles invalid url gracefully', () => {
+      const event: HightouchEvent = {
+        type: 'page',
+        properties: {
+          url: 'not-a-valid-url',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      // Should fall back to default path when url is invalid
+      expect(event.properties?.path).toBe('/default-path')
+      expect(event.context?.page?.path).toBe('/default-path')
+    })
+
+    it('handles url with encoded characters', () => {
+      const event: HightouchEvent = {
+        type: 'page',
+        properties: {
+          url: 'https://example.com/path%20with%20spaces',
+        },
+        context: {},
+      }
+
+      addPageContext(event, mockPageCtx)
+
+      expect(event.properties?.path).toBe('/path%20with%20spaces')
+      expect(event.context?.page?.path).toBe('/path%20with%20spaces')
     })
   })
 })

--- a/packages/browser/src/core/page/add-page-context.ts
+++ b/packages/browser/src/core/page/add-page-context.ts
@@ -3,6 +3,18 @@ import { EventProperties, HightouchEvent } from '../events'
 import { getDefaultPageContext } from './get-page-context'
 
 /**
+ * Parses the path from a URL string.
+ * Returns undefined if the URL is invalid.
+ */
+const parsePathFromUrl = (url: string): string | undefined => {
+  try {
+    return new URL(url).pathname
+  } catch (_e) {
+    return undefined
+  }
+}
+
+/**
  * Augments an event with information about the current page.
  * Page information like URL changes frequently, so this is meant to be captured as close to the event call as possible.
  * Things like `userAgent` do not change, so they can be added later in the flow.
@@ -14,13 +26,33 @@ export const addPageContext = (
 ): void => {
   const evtCtx = event.context! // Context should be set earlier in the flow
   let pageContextFromEventProps: Pick<EventProperties, string> | undefined
+  let derivedPath: string | undefined
+
   if (event.type === 'page') {
     pageContextFromEventProps =
       event.properties && pick(event.properties, Object.keys(pageCtx))
 
+    // If user provided url but not path, derive path from the url.
+    // This is important for SPAs where the url may be manually set but path
+    // would otherwise be auto-detected from location.pathname which may be stale.
+    if (pageContextFromEventProps) {
+      const userUrl = pageContextFromEventProps['url']
+      const userPath = pageContextFromEventProps['path']
+      if (userUrl && typeof userUrl === 'string' && !userPath) {
+        derivedPath = parsePathFromUrl(userUrl)
+        if (derivedPath) {
+          pageContextFromEventProps = {
+            ...pageContextFromEventProps,
+            path: derivedPath,
+          }
+        }
+      }
+    }
+
     event.properties = {
       ...pageCtx,
       ...event.properties,
+      ...(derivedPath ? { path: derivedPath } : {}),
       ...(event.name ? { name: event.name } : {}),
     }
   }


### PR DESCRIPTION
Derive `path` from user-provided `url` in `page` calls when `path` is not explicitly provided.

This fixes an issue where `path` could be stale when `url` and `referrer` were manually overridden, ensuring `path` is consistent with the provided `url` in single-page applications.

---
[Slack Thread](https://carryinternal.slack.com/archives/C03BQGJP46S/p1771956284543999?thread_ts=1771956284.543999&cid=C03BQGJP46S)

<p><a href="https://cursor.com/agents/bc-fde4a404-e220-5042-b913-08904db413c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fde4a404-e220-5042-b913-08904db413c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

