### PR TITLE
Normalize brand + version fields in user agent data

### DIFF
--- a/packages/browser/src/lib/client-hints/__tests__/index.test.ts
+++ b/packages/browser/src/lib/client-hints/__tests__/index.test.ts
@@ -63,4 +63,29 @@ describe('Client Hints API', () => {
       bitness: '64',
     })
   })
+
+  it('normalizes Pascal-cased `Brand`/`Version` on `brands` to spec lowercase keys', async () => {
+    const pascalCasedBrands = {
+      brands: [
+        { Brand: 'Microsoft Edge', Version: '143' },
+        { Brand: 'Chromium', Version: '143' },
+        { brand: 'Not A(Brand', Version: '99' },
+      ],
+      mobile: false,
+      platform: 'Windows',
+    }
+
+    ;(window.navigator as any).userAgentData = {
+      ...pascalCasedBrands,
+      getHighEntropyValues: jest.fn(() => Promise.resolve(pascalCasedBrands)),
+      toJSON: jest.fn(() => pascalCasedBrands),
+    }
+
+    const lowEntropy = await clientHints()
+    expect(lowEntropy?.brands).toEqual([
+      { brand: 'Microsoft Edge', version: '143' },
+      { brand: 'Chromium', version: '143' },
+      { brand: 'Not A(Brand', version: '99' },
+    ])
+  })
 })

--- a/packages/browser/src/lib/client-hints/index.ts
+++ b/packages/browser/src/lib/client-hints/index.ts
@@ -1,5 +1,20 @@
 import { HighEntropyHint, NavigatorUAData, UADataValues } from './interfaces'
 
+// Tolerate Pascal-cased `Brand` / `Version` aliases emitted by some polyfills
+// and enterprise wrappers on `brands` entries. The W3C spec only defines
+// lowercase `brand` / `version`
+// (https://wicg.github.io/ua-client-hints/#dictdef-navigatoruabrandversion),
+// and downstream consumers read those, so we coerce to lowercase here.
+function normalizeBrands(
+  brands: UADataValues['brands']
+): UADataValues['brands'] {
+  return brands?.map(({ Brand, Version, brand, version, ...rest }: any) => ({
+    ...rest,
+    brand: brand ?? Brand,
+    version: version ?? Version,
+  }))
+}
+
 export async function clientHints(
   hints?: HighEntropyHint[]
 ): Promise<UADataValues | undefined> {
@@ -9,8 +24,11 @@ export async function clientHints(
 
   if (!userAgentData) return undefined
 
-  if (!hints) return userAgentData.toJSON()
-  return userAgentData
-    .getHighEntropyValues(hints)
-    .catch(() => userAgentData.toJSON())
+  const data = !hints
+    ? userAgentData.toJSON()
+    : await userAgentData
+        .getHighEntropyValues(hints)
+        .catch(() => userAgentData.toJSON())
+
+  return { ...data, brands: normalizeBrands(data.brands) }
 }


### PR DESCRIPTION
The [W3C UA Client Hints spec](https://wicg.github.io/ua-client-hints/#dictdef-navigatoruabrandversion) defines brand entries as `{ brand, version }` lowercase, but we are noticing some instances of Pascal-cased Brand / Version on `userAgentData.brands`. We should normalize these to lowercase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved inconsistencies in client hints brand and version data formatting. The API now ensures all brand and version values are normalized to lowercase regardless of the source or original casing format.

* **Tests**
  * Added test coverage verifying that client hints correctly normalizes brand and version values to lowercase, including handling mixed casing formats from various data sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ht-sdks/events-sdk-js-mono/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->