### PR TITLE
fix(browser): use fixed __tld__ name for cookie domain probe

### DIFF
--- a/packages/browser/src/core/user/tld.ts
+++ b/packages/browser/src/core/user/tld.ts
@@ -47,7 +47,7 @@ export function tld(url: string): string | undefined {
 
   // Test for the top most domain that the browser allows
   for (let i = 0; i < lvls.length; ++i) {
-    const cname = Math.round(Math.random() * 10_000).toString()
+    const cname = '__tld__'
     const domain = lvls[i]
     const opts = {
       domain: '.' + domain,


### PR DESCRIPTION
The random cookie names from #16 (safari bug fix) show up in automated cookie audits and look like tracking noise.

While looking at how to reduce that noise, I retested the original bug, and I've confirmed that the original Safari bug has actually been fixed. Therefore, we can go back to using a static probe cookie always named `__tld__`.

The original bug was that on Safari circa 2024:

> Expected
> ```
> // when on a site like foo.bob.example.com where foo.bob subdomain is a different permission than example.com
> cookie.set(name, '1', domain=example.com)
> cookie.get(name) => undefined (e.g. you're NOT allowed to set cookie for this domain)
> cookie.set(name, '1', domain=foo.bob.example.com)
> cookie.get(name) => '1' (e.g. you ARE allowed to set cookie for this domain)
>
> // page refresh
> cookie.set(name, '1', domain=example.com)
> **cookie.get(name) => undefined (e.g. you're NOT allowed to set cookie for this domain)**
> ```
>
> Actual (circa 2024 in Safair)
> ```
> // when on a site like foo.bob.example.com where foo.bob subdomain is a different permission than example.com
> cookie.set(name, '1', domain=example.com)
> cookie.get(name) => undefined (e.g. you're NOT allowed to set cookie for this domain)
> cookie.set(name, '1', domain=foo.bob.example.com)
> cookie.get(name) => '1' (e.g. you ARE allowed to set cookie for this domain)
>
> // page refresh
> cookie.set(name, '1', domain=example.com)
> **cookie.get(name) => "value" (e.g. THIS IS WRONG)**
> ```

My best guess is that either there was a caching bug or a concurrency bug. Rapidly deleting/setting cookies was returning values from previous commands setting cookies. Not from the actual latest command.

I've verified that WebKit no longer reproduces: verified in Safari (June 2026) on hosting domains (`*.lambda-url.*.on.aws`, `*.github.io`) and single owner domains (`uk.news.yahoo`, etc) across repeated runs, refreshes, and navigations - the probe correctly fails on public suffixes and only succeeds on the real host.

---

### Why are we setting and deleting cookies at all?

Because we want to know what domain we can set our actual real cookies on. 

If a user visits foo.bar.example.com, it'd be nice to set the cookie on example.com (if allowed) so that the session extends across all subdomains. Sometimes thats not allowed though (and we have to go with a cookie on foo.bar.example.com). To make this decision, we need to test the browser on which domains are allowed by setting/getting actual real-but-throw-away cookies. We use a hardcoded value of `1` that has no relation to the specific user.